### PR TITLE
Actor: Pick smallest delta when moving away from block

### DIFF
--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -196,9 +196,7 @@ internal final class Grid {
         }
 
         for block in tile.blocks {
-            let actorRect = actor.rectForCollisionDetection
-
-            guard actorRect.intersects(block.rect) else {
+            guard actor.rectForCollisionDetection.intersects(block.rect) else {
                 continue
             }
 
@@ -206,17 +204,7 @@ internal final class Grid {
 
             if let group = block.group {
                 if actor.constraints.contains(.neverOverlapBlockInGroup(group)) {
-                    if actorRect.minX > block.rect.minX && actorRect.maxX < block.rect.maxX {
-                        if actorRect.maxY > block.rect.minY && actor.position.y < block.rect.midY {
-                            actor.position.y = block.rect.minY - actor.size.height / 2
-                        } else {
-                            actor.position.y = block.rect.maxY + actor.size.height / 2
-                        }
-                    } else if actorRect.maxX > block.rect.minX && actor.position.x < block.rect.midX  {
-                        actor.position.x = block.rect.minX - actor.size.width / 2
-                    } else {
-                        actor.position.x = block.rect.maxX + actor.size.width / 2
-                    }
+                    move(actor, awayFrom: block)
                 }
             }
         }
@@ -242,6 +230,30 @@ internal final class Grid {
 
         if let group = block.group {
             actor.events.collided(withBlockInGroup: group).trigger(with: block)
+        }
+    }
+
+    private func move(_ actor: Actor, awayFrom block: Block) {
+        let actorRect = actor.rectForCollisionDetection
+        let distanceX: Metric
+        let distanceY: Metric
+
+        if actor.position.x > block.rect.midX {
+            distanceX = block.rect.maxX - actorRect.minX
+        } else {
+            distanceX = block.rect.minX - actorRect.maxX
+        }
+
+        if actor.position.y > block.rect.midY {
+            distanceY = block.rect.maxY - actorRect.minY
+        } else {
+            distanceY = block.rect.minY - actorRect.maxY
+        }
+
+        if abs(distanceX) < abs(distanceY) {
+            actor.position.x += distanceX
+        } else {
+            actor.position.y += distanceY
         }
     }
 }

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -100,6 +100,12 @@ final class ActorTests: XCTestCase {
         // Approaching from the bottom should stop the actor at the block's bottom edge
         actor.position = Point(x: 0, y: 180)
         XCTAssertEqual(actor.position.y, 200)
+
+        // When moving the actor away, the least possible distance should be picked
+        actor.position = Point(x: 180, y: -190)
+        XCTAssertEqual(actor.position, Point(x: 180, y: -200))
+        actor.position = Point(x: 190, y: -180)
+        XCTAssertEqual(actor.position, Point(x: 200, y: -180))
     }
 
     func testObservingMove() {


### PR DESCRIPTION
This patch fixes a bug that would cause an actor to be moved to an incorrect side of a block, when it has a constraint to never overlap a block in a given group.

The fix is to calculate the smallest possible delta to move the actor by, and pick that delta when moving the actor away. The result is that the actor will now snap to the most logical edge of the block instead of being moved to another one of the block’s sides.