### PR TITLE
Actor: Render first animation frame directly

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -148,6 +148,8 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
         if isClickable {
             scene?.add(ClickPlugin())
         }
+
+        renderFirstAnimationFrameIfNeeded()
     }
 
     private func positionDidChange(from oldValue: Point) {
@@ -209,6 +211,12 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
             return
         }
 
+        renderFirstAnimationFrameIfNeeded()
+
+        guard animation.frames.count > 1 else {
+            return
+        }
+
         let action = AnimationAction(animation: animation, triggeredByActor: true)
         animationActionToken = perform(action)
     }
@@ -217,6 +225,21 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
         if oldValue == false && isHitTestingEnabled == true {
             rectDidChange()
         }
+    }
+
+    private func renderFirstAnimationFrameIfNeeded() {
+        guard let animation = animation else {
+            return
+        }
+
+        guard let firstFrame = animation.frames.first else {
+            return
+        }
+
+        render(texture: firstFrame,
+               scale: animation.textureScale,
+               resize: animation.autoResize,
+               ignoreNamePrefix: animation.ignoreTextureNamePrefix)
     }
 }
 

--- a/Sources/Core/API/Animation.swift
+++ b/Sources/Core/API/Animation.swift
@@ -60,7 +60,7 @@ public extension Animation {
         updateIdentifier()
     }
 
-    init(texturesNamed textureNames: [String], frameDuration: TimeInterval = 1) {
+    init(texturesNamed textureNames: [String], frameDuration: TimeInterval) {
         frames = textureNames.map(Texture.init)
         self.frameDuration = frameDuration
         updateIdentifier()
@@ -68,6 +68,12 @@ public extension Animation {
 
     init(image: Image) {
         frames = [Texture(image: image)]
+        updateIdentifier()
+    }
+
+    init(images: [Image], frameDuration: TimeInterval) {
+        frames = images.map(Texture.init)
+        self.frameDuration = frameDuration
         updateIdentifier()
     }
 }

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -24,12 +24,49 @@ final class ActorTests: XCTestCase {
     // MARK: - Tests
 
     func testAnimationAutoResizingActor() {
+        let imageSizes = [
+            Size(width: 200, height: 150),
+            Size(width: 300, height: 50),
+            Size(width: 100, height: 90)
+        ]
+
+        let images = imageSizes.map(ImagineMockFactory.makeImage)
+        actor.animation = Animation(images: images, frameDuration: 1.5)
+
+        // The actor should directly render the first frame
+        XCTAssertEqual(actor.size, imageSizes[0])
+
+        // Perform a game update to start the animation
+        game.update()
+
+        // After 1.5 seconds the second frame should be rendered, and the actor resized
+        game.timeTraveler.travel(by: 1.5)
+        game.update()
+        XCTAssertEqual(actor.size, imageSizes[1])
+
+        // Same thing for the third frame
+        game.timeTraveler.travel(by: 1.5)
+        game.update()
+        XCTAssertEqual(actor.size, imageSizes[2])
+
+        // After an additional 1.5 seconds, the initial frame should again be rendered
+        game.timeTraveler.travel(by: 1.5)
+        game.update()
+        XCTAssertEqual(actor.size, imageSizes[0])
+    }
+
+    func testSettingActorInitialSizeFromAnimation() {
         let imageSize = Size(width: 200, height: 150)
         let image = ImagineMockFactory.makeImage(withSize: imageSize)
 
+        let actor = Actor()
         actor.animation = Animation(image: image)
-        game.update()
 
+        // Before being added to the scene, the actor's size should remain zero
+        XCTAssertEqual(actor.size, .zero)
+
+        // As soon as the actor is added, it should be resized (even without an update)
+        game.scene.add(actor)
         XCTAssertEqual(actor.size, imageSize)
     }
 


### PR DESCRIPTION
This change makes actors render their initial animation frame directly when the animation is assigned, rather than waiting for the next screen update. The reason for this is to enable the actor’s size to be set as soon as it’s added to a scene, to enable easier positioning.

This also enables an optimization path in that an animation action does not have to be added in case only a single frame is being rendered.

This change also includes a new convenience API to create an animation from an array of images, which enables more thorough testing of the resizing feature.