### PR TITLE
Mac: Run game on the main thread

### DIFF
--- a/Sources/Core/Internal/DisplayLink-macOS.swift
+++ b/Sources/Core/Internal/DisplayLink-macOS.swift
@@ -33,10 +33,8 @@ internal final class DisplayLink: DisplayLinkProtocol {
         CVDisplayLinkStart(link)
     }
     
-    // MARK: - Private
-    
-    @objc internal func screenDidRender() {
-        callback()
+    @objc func screenDidRender() {
+        DispatchQueue.main.async(execute: callback)
     }
 }
 


### PR DESCRIPTION
CVDisplayLink gets called on a background thread, to maintain consistency with iOS we dispatch the game’s callback on the main queue.