### PR TITLE
Add support for sprite sheet-based animations

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		522CD6A41F8D4521008DB43D /* View+MakeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6641F8D4512008DB43D /* View+MakeLayer.swift */; };
 		522CD6A51F8D4526008DB43D /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6671F8D4512008DB43D /* GameViewController.swift */; };
 		522CD6A61F8D4526008DB43D /* GameWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6681F8D4512008DB43D /* GameWindow.swift */; };
+		523E5D101F9FEFBC0084792C /* SpriteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523E5D0F1F9FEFBC0084792C /* SpriteSheet.swift */; };
+		523E5D111F9FEFBC0084792C /* SpriteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523E5D0F1F9FEFBC0084792C /* SpriteSheet.swift */; };
 		52479F801F8E58E200D22A87 /* TextureImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52479F7F1F8E58E200D22A87 /* TextureImageLoader.swift */; };
 		52479F821F8E5A6F00D22A87 /* TextureImageLoaderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52479F811F8E5A6F00D22A87 /* TextureImageLoaderMock.swift */; };
 		52479F841F8E7B4E00D22A87 /* SceneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52479F831F8E7B4E00D22A87 /* SceneTests.swift */; };
@@ -246,6 +248,7 @@
 		522CD6641F8D4512008DB43D /* View+MakeLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+MakeLayer.swift"; sourceTree = "<group>"; };
 		522CD6671F8D4512008DB43D /* GameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewController.swift; sourceTree = "<group>"; };
 		522CD6681F8D4512008DB43D /* GameWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameWindow.swift; sourceTree = "<group>"; };
+		523E5D0F1F9FEFBC0084792C /* SpriteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteSheet.swift; sourceTree = "<group>"; };
 		52479F7F1F8E58E200D22A87 /* TextureImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureImageLoader.swift; sourceTree = "<group>"; };
 		52479F811F8E5A6F00D22A87 /* TextureImageLoaderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureImageLoaderMock.swift; sourceTree = "<group>"; };
 		52479F831F8E7B4E00D22A87 /* SceneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneTests.swift; sourceTree = "<group>"; };
@@ -358,6 +361,7 @@
 				522CD6481F8D4512008DB43D /* ScaleAction.swift */,
 				522CD6491F8D4512008DB43D /* Scene.swift */,
 				522CD64A1F8D4512008DB43D /* SceneEventCollection.swift */,
+				523E5D0F1F9FEFBC0084792C /* SpriteSheet.swift */,
 				522CD64B1F8D4512008DB43D /* Texture.swift */,
 				52479F7F1F8E58E200D22A87 /* TextureImageLoader.swift */,
 				522CD6601F8D4512008DB43D /* TextureManager.swift */,
@@ -717,6 +721,7 @@
 				522CD6A41F8D4521008DB43D /* View+MakeLayer.swift in Sources */,
 				522CD69D1F8D4521008DB43D /* PluginWrapper.swift in Sources */,
 				522CD6881F8D451D008DB43D /* Scalable.swift in Sources */,
+				523E5D101F9FEFBC0084792C /* SpriteSheet.swift in Sources */,
 				522CD6831F8D451D008DB43D /* Plugin.swift in Sources */,
 				522CD66D1F8D451D008DB43D /* ActorEventCollection.swift in Sources */,
 				522CD6811F8D451D008DB43D /* Movable.swift in Sources */,
@@ -855,6 +860,7 @@
 				DD21B71E1F92E75A0034A7CE /* Action.swift in Sources */,
 				DD21B71F1F92E75A0034A7CE /* Texture.swift in Sources */,
 				DD21B7201F92E75A0034A7CE /* UpdateOutcome.swift in Sources */,
+				523E5D111F9FEFBC0084792C /* SpriteSheet.swift in Sources */,
 				DD21B7211F92E75A0034A7CE /* MetricAction.swift in Sources */,
 				DD21B7221F92E75A0034A7CE /* Animation.swift in Sources */,
 				DD21B7231F92E75A0034A7CE /* Game.swift in Sources */,

--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -118,18 +118,23 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
 
     // MARK: - Internal
 
-    internal func render(texture: Texture, scale: Int?, resize: Bool, ignoreNamePrefix: Bool) {
+    internal func render(frame: Animation.Frame, scale: Int?, resize: Bool, ignoreNamePrefix: Bool) {
         guard let textureManager = scene?.textureManager else {
             return
         }
 
         let namePrefix = ignoreNamePrefix ? nil : textureNamePrefix
-        let loadedTexture = textureManager.load(texture, namePrefix: namePrefix, scale: scale)
+        let loadedTexture = textureManager.load(frame.texture, namePrefix: namePrefix, scale: scale)
 
         layer.contents = loadedTexture?.image
+        layer.contentsRect = frame.contentRect
 
         if resize {
-            size = loadedTexture?.size ?? .zero
+            if var newSize = loadedTexture?.size {
+                newSize.width *= frame.contentRect.width
+                newSize.height *= frame.contentRect.height
+                size = newSize
+            }
         }
     }
 
@@ -215,7 +220,7 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
 
         renderFirstAnimationFrameIfNeeded()
 
-        guard animation.frames.count > 1 else {
+        guard animation.frameCount > 1 else {
             return
         }
 
@@ -241,11 +246,11 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
             return
         }
 
-        guard let firstFrame = animation.frames.first else {
+        guard animation.frameCount > 0 else {
             return
         }
 
-        render(texture: firstFrame,
+        render(frame: animation.frame(at: 0),
                scale: animation.textureScale,
                resize: animation.autoResize,
                ignoreNamePrefix: animation.ignoreTextureNamePrefix)

--- a/Sources/Core/API/AnimationAction.swift
+++ b/Sources/Core/API/AnimationAction.swift
@@ -37,19 +37,19 @@ public final class AnimationAction: Action<Actor> {
     }
 
     internal override func update(for actor: Actor, currentTime: TimeInterval) -> UpdateOutcome {
-        let frame = animation.frames[frameIndex]
+        let frame = animation.frame(at: frameIndex)
         frameIndex += 1
 
-        actor.render(texture: frame,
+        actor.render(frame: frame,
                      scale: animation.textureScale,
                      resize: animation.autoResize,
                      ignoreNamePrefix: animation.ignoreTextureNamePrefix)
 
-        if animation.frames.count < 2 {
+        if animation.frameCount < 2 {
             return .finished
         }
 
-        if frameIndex == animation.frames.count {
+        if frameIndex == animation.frameCount {
             switch animation.repeatMode {
             case .times(let count):
                 guard repeatCount < count else {

--- a/Sources/Core/API/SpriteSheet.swift
+++ b/Sources/Core/API/SpriteSheet.swift
@@ -1,0 +1,38 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+
+/**
+ *  Type used to describe a sprite sheet used with an animation
+ *
+ *  A sprite sheet is a single texture that contains multiple frames
+ *  of an animation. Its texture can have multiple rows and any number
+ *  of frames, but it's important that the source image contains evenly
+ *  divided frames.
+ *
+ *  For example, if a sprite sheet is 100x100 pixels large and it is said
+ *  to have 16 frames and 4 rows, then each frame is assumed to be a 20x20
+ *  cutout from the sprite sheet's texture.
+ *
+ *  To use a sprite sheet with an animation, either assign it as its `content`
+ *  property, or use the initializer `Animation(spriteSheetNamed:...)`.
+ */
+public struct SpriteSheet {
+    /// The texture that makes up the sprite sheet's frames
+    public var texture: Texture
+    /// The total number of frames contained within the sprite sheet
+    public var frameCount: Int
+    /// The number of rows that the sprite sheet contains
+    public var rowCount: Int
+
+    /// Initialize an instance with a texture + number of frames & rows
+    public init(texture: Texture, frameCount: Int, rowCount: Int = 1) {
+        self.texture = texture
+        self.frameCount = frameCount
+        self.rowCount = rowCount
+    }
+}

--- a/Sources/Core/API/SpriteSheet.swift
+++ b/Sources/Core/API/SpriteSheet.swift
@@ -15,7 +15,7 @@ import Foundation
  *  divided frames.
  *
  *  For example, if a sprite sheet is 100x100 pixels large and it is said
- *  to have 16 frames and 4 rows, then each frame is assumed to be a 20x20
+ *  to have 16 frames and 4 rows, then each frame is assumed to be a 25x25
  *  cutout from the sprite sheet's texture.
  *
  *  To use a sprite sheet with an animation, either assign it as its `content`

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -80,6 +80,29 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(actor.size, imageSize)
     }
 
+    func testAnimatingWithSpriteSheet() {
+        let imageSize = Size(width: 300, height: 100)
+        let image = ImagineMockFactory.makeImage(withSize: imageSize)
+        game.textureImageLoader.images["sheet"] = image.cgImage
+
+        var animation = Animation(
+            spriteSheetNamed: "sheet",
+            frameCount: 6,
+            rowCount: 2,
+            frameDuration: 1
+        )
+        animation.textureScale = 1
+
+        let actor = Actor()
+        actor.animation = animation
+        game.scene.add(actor)
+        XCTAssertEqual(actor.size, Size(width: 100, height: 50))
+
+        game.timeTraveler.travel(by: 1)
+        game.update()
+        XCTAssertEqual(actor.size, Size(width: 100, height: 50))
+    }
+
     func testTextureNamePrefix() {
         actor.textureNamePrefix = "Prefix"
 


### PR DESCRIPTION
This change adds support for using a single sprite sheet texture for an animation, that lets an actor animate over sub-rectangles of that texture, which can contain a single or multiple rows.

This new feature is a compliment to the already existing option of using separate image files for each texture. The advantage of using a sprite sheet is that only a single image needs to be loaded into memory, and drawing can be done by simply offsetting that single texture instead of having to draw a completely new one.

This change very slightly breaks the existing `Animation` API in that an array of textures need to be wrapped in a `.textures` enum case if assigned directly to an existing animation.