### PR TITLE
Scene: Adjust click points for macOS + camera position

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5204849D1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
+		5204849E1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
+		520484A21FA357070011D372 /* ClickGestureRecognizer-macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */; };
 		522CD6691F8D451D008DB43D /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6281F8D4512008DB43D /* Action.swift */; };
 		522CD66A1F8D451D008DB43D /* ActionPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6291F8D4512008DB43D /* ActionPerformer.swift */; };
 		522CD66B1F8D451D008DB43D /* ActionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD62A1F8D4512008DB43D /* ActionToken.swift */; };
@@ -190,6 +193,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickGestureRecognizerMock.swift; sourceTree = "<group>"; };
+		5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClickGestureRecognizer-macOS.swift"; sourceTree = "<group>"; };
 		522CD6281F8D4512008DB43D /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		522CD6291F8D4512008DB43D /* ActionPerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionPerformer.swift; sourceTree = "<group>"; };
 		522CD62A1F8D4512008DB43D /* ActionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionToken.swift; sourceTree = "<group>"; };
@@ -380,6 +385,7 @@
 				522CD64F1F8D4512008DB43D /* ActionManager.swift */,
 				522CD6501F8D4512008DB43D /* ActionWrapper.swift */,
 				522CD6511F8D4512008DB43D /* Activatable.swift */,
+				5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */,
 				522CD6521F8D4512008DB43D /* ClickPlugin.swift */,
 				522CD6531F8D4512008DB43D /* ClosureUpdatable.swift */,
 				52C860371F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift */,
@@ -437,6 +443,7 @@
 			isa = PBXGroup;
 			children = (
 				52479F8D1F8E823E00D22A87 /* ActionMock.swift */,
+				5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */,
 				52C8603C1F8E537C00C6C7A7 /* DisplayLinkMock.swift */,
 				52C8603A1F8E535100C6C7A7 /* GameMock.swift */,
 				52479F871F8E7CAF00D22A87 /* PluginMock.swift */,
@@ -716,6 +723,7 @@
 				525688CD1F9CF3E200F87786 /* DisplayLinkMock.swift in Sources */,
 				525688CF1F9CF3E200F87786 /* PluginMock.swift in Sources */,
 				525688CB1F9CF3E200F87786 /* TimelineTests.swift in Sources */,
+				5204849E1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -810,6 +818,7 @@
 				52479F851F8E7BFA00D22A87 /* Assert.swift in Sources */,
 				52479F8C1F8E818100D22A87 /* ActionTests.swift in Sources */,
 				52479F821F8E5A6F00D22A87 /* TextureImageLoaderMock.swift in Sources */,
+				5204849D1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -821,6 +830,7 @@
 				DD21B6F31F92E75A0034A7CE /* PluginWrapper.swift in Sources */,
 				DD21B6F41F92E75A0034A7CE /* Scalable.swift in Sources */,
 				DD21B6F51F92E75A0034A7CE /* Plugin.swift in Sources */,
+				520484A21FA357070011D372 /* ClickGestureRecognizer-macOS.swift in Sources */,
 				DD21B6F61F92E75A0034A7CE /* ActorEventCollection.swift in Sources */,
 				DD21B6F71F92E75A0034A7CE /* Movable.swift in Sources */,
 				DD21B7411F92EA610034A7CE /* ClickPlugin.swift in Sources */,

--- a/Sources/Core/API/Camera.swift
+++ b/Sources/Core/API/Camera.swift
@@ -15,9 +15,11 @@ import Foundation
  */
 public final class Camera: ActionPerformer, Movable, Activatable {
     /// The position of the camera within its scene
-    public var position = Point() { didSet { updateLayerFrame() } }
+    public var position = Point() { didSet { update() } }
     /// The size of the camera's viewport. Set as soon as its presented in a game.
-    public internal(set) var size = Size() { didSet { updateLayerFrame() }}
+    public internal(set) var size = Size() { didSet { update() }}
+    /// The current rectangle of the camera's viewport.
+    public private(set) var rect = Rect()
 
     private let pluginManager = PluginManager()
     private lazy var actionManager = ActionManager(object: self)
@@ -60,10 +62,15 @@ public final class Camera: ActionPerformer, Movable, Activatable {
 
     // MARK: - Private
 
-    private func updateLayerFrame() {
+    private func update() {
         layer.frame.origin = Point(
             x: size.width / 2 - position.x,
             y: size.height / 2 - position.y
         )
+
+        var newRect = Rect(origin: position, size: size)
+        newRect.origin.x -= size.width / 2
+        newRect.origin.y -= size.height / 2
+        rect = newRect
     }
 }

--- a/Sources/Core/Internal/ClickGestureRecognizer-macOS.swift
+++ b/Sources/Core/Internal/ClickGestureRecognizer-macOS.swift
@@ -1,0 +1,14 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Cocoa
+
+extension ClickGestureRecognizer {
+    func addTarget(_ target: AnyObject, action: Selector) {
+        self.target = target
+        self.action = action
+    }
+}

--- a/Tests/ImagineEngineTests/CameraTests.swift
+++ b/Tests/ImagineEngineTests/CameraTests.swift
@@ -31,6 +31,21 @@ final class CameraTests: XCTestCase {
         XCTAssertEqual(scene.camera.size, Size(width: 100, height: 100))
     }
 
+    func testRect() {
+        // Initially the camera should have a zero size rect at the scene's center point
+        let scene = Scene(size: Size(width: 500, height: 300))
+        XCTAssertEqual(scene.camera.rect, Rect(x: 250, y: 150, width: 0, height: 0))
+
+        // When the scene is added to a game the rect should be the full view port
+        game.view.frame.size = Size(width: 100, height: 200)
+        game.scene = scene
+        XCTAssertEqual(scene.camera.rect, Rect(x: 200, y: 50, width: 100, height: 200))
+
+        // When the camera is moved, the rect should be updated
+        scene.camera.position = Point(x: 50, y: 100)
+        XCTAssertEqual(scene.camera.rect, Rect(x: 0, y: 0, width: 100, height: 200))
+    }
+
     func testAddingAndRemovingPlugin() {
         let plugin = PluginMock<Camera>()
 

--- a/Tests/ImagineEngineTests/Mocks/ClickGestureRecognizerMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/ClickGestureRecognizerMock.swift
@@ -1,0 +1,20 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+@testable import ImagineEngine
+
+final class ClickGestureRecognizerMock: ClickGestureRecognizer {
+    var location: Point?
+
+    override func location(in view: View?) -> Point {
+        if let location = location {
+            return location
+        }
+
+        return super.location(in: view)
+    }
+}

--- a/Tests/ImagineEngineTests/Mocks/GameMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/GameMock.swift
@@ -13,6 +13,8 @@ final class GameMock: Game {
 
     private let displayLink = DisplayLinkMock()
     private let containerView = View()
+    private let clickGestureRecognizer = ClickGestureRecognizerMock()
+    private lazy var clickPlugin = ClickPlugin(gestureRecognizer: clickGestureRecognizer)
 
     init() {
         let scene = Scene(size: Size(width: 500, height: 500))
@@ -23,6 +25,8 @@ final class GameMock: Game {
                    displayLink: displayLink,
                    dateProvider: timeTraveler.generateDate)
 
+        scene.add(clickPlugin)
+
         view.frame.size = scene.size
         containerView.addSubview(view)
         updateActivationStatus()
@@ -30,5 +34,17 @@ final class GameMock: Game {
 
     func update() {
         displayLink.callback()
+    }
+
+    func simulateClick(at point: Point) {
+        // The mac's coordinate system has its origin in the bottom left
+        #if os(macOS)
+        var point = point
+        point.y = view.bounds.height - point.y
+        #endif
+
+        clickGestureRecognizer.location = point
+        clickPlugin.trigger()
+        clickGestureRecognizer.location = nil
     }
 }

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -131,4 +131,30 @@ final class SceneTests: XCTestCase {
         game.update()
         XCTAssertEqual(actor.position, Point(x: 80, y: 80))
     }
+
+    func testClickPointAdjustedForCamera() {
+        var clickedPoint: Point?
+
+        game.scene.events.clicked.observe { _, point in
+            clickedPoint = point
+        }
+
+        // When the scene & the camera are of the same size, no adjustments are needed
+        game.view.frame.size = Size(width: 300, height: 600)
+        game.scene.size = game.view.frame.size
+        game.scene.camera.position = game.scene.center
+        game.simulateClick(at: Point(x: 150, y: 300))
+        XCTAssertEqual(clickedPoint, Point(x: 150, y: 300))
+
+        // When camera in the upper-left corner, no adjustments are needed either
+        game.scene.size = Size(width: 3000, height: 6000)
+        game.scene.camera.position = Point(x: 150, y: 300)
+        game.simulateClick(at: Point(x: 150, y: 300))
+        XCTAssertEqual(clickedPoint, Point(x: 150, y: 300))
+
+        // When camera is moved, the click point should be adjusted accordingly
+        game.scene.camera.position = Point(x: 1000, y: 1500)
+        game.simulateClick(at: Point(x: 200, y: 350))
+        XCTAssertEqual(clickedPoint, Point(x: 1050, y: 1550))
+    }
 }


### PR DESCRIPTION
This patch fixes 2 bugs when it comes to what point is passed into a scene’s click event handler:

1. On macOS, an incorrect y coordinate was passed, since macOS uses a bottom-left anchored coordinate system.

2. When a scene’s camera was moved, the camera’s position wasn’t taken into account when computing the clicked point.

This change also adds a `rect` property to `Camera`, which is being used in the fix.