### PR TITLE
Actor: Add ‘willMove’ event

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -34,7 +34,10 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
     /// The index of the actor on the z axis. Affects rendering & hit testing. 0 = implicit index.
     public var zIndex = 0 { didSet { layer.zPosition = Metric(zIndex) } }
     /// The position (center-point) of the actor within its scene.
-    public var position = Point() { didSet { positionDidChange(from: oldValue) } }
+    public var position = Point() {
+        willSet { positionWillChange(to: newValue) }
+        didSet { positionDidChange(from: oldValue) }
+    }
     /// The size of the actor (centered on its position).
     public var size = Size() { didSet { sizeDidChange(from: oldValue) } }
     /// The rectangle the actor currently occupies within its scene.
@@ -155,6 +158,12 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
         }
 
         renderFirstAnimationFrameIfNeeded()
+    }
+
+    private func positionWillChange(to newValue: Point) {
+        if position != newValue {
+            events.willMove.trigger(with: newValue)
+        }
     }
 
     private func positionDidChange(from oldValue: Point) {

--- a/Sources/Core/API/ActorEventCollection.swift
+++ b/Sources/Core/API/ActorEventCollection.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Events that can be used to observe an actor
 public final class ActorEventCollection: EventCollection<Actor> {
+    /// Event triggered when the actor is about to move (contains the new position)
+    public private(set) lazy var willMove = Event<Actor, Point>(object: self.object)
     /// Event triggered when the actor was moved
     public private(set) lazy var moved = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor was resized

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -178,6 +178,26 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(actor.position, Point(x: 200, y: -180))
     }
 
+    func testObservingWillMoveEvent() {
+        var noValueTriggerCount = 0
+        actor.events.willMove.observe { noValueTriggerCount += 1 }
+
+        var oldPositions = [Point]()
+        var newPositions = [Point]()
+
+        actor.events.willMove.observe { actor, newPosition in
+            oldPositions.append(actor.position)
+            newPositions.append(newPosition)
+        }
+
+        actor.position.x += 100
+        actor.position.y += 50
+
+        XCTAssertEqual(noValueTriggerCount, 2)
+        XCTAssertEqual(oldPositions, [.zero, Point(x: 100, y: 0)])
+        XCTAssertEqual(newPositions, [Point(x: 100, y: 0), Point(x: 100, y: 50)])
+    }
+
     func testObservingMove() {
         var noValueTriggerCount = 0
         actor.events.moved.observe { noValueTriggerCount += 1 }


### PR DESCRIPTION
This new event will be triggered right before an actor is moved, and contains the new position that the actor will be moved to.