### PR TITLE
Animation: Fix missing identifier when using a sprite sheet

### DIFF
--- a/Sources/Core/API/Animation.swift
+++ b/Sources/Core/API/Animation.swift
@@ -99,6 +99,8 @@ public extension Animation {
         self.repeatMode = repeatMode
         self.autoResize = autoResize
         self.ignoreTextureNamePrefix = ignoreTextureNamePrefix
+
+        updateIdentifier()
     }
 }
 

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -101,6 +101,19 @@ final class ActorTests: XCTestCase {
         game.timeTraveler.travel(by: 1)
         game.update()
         XCTAssertEqual(actor.size, Size(width: 100, height: 50))
+
+        // Assigning new sprite sheet mid-animation should update the animation
+        var newAnimation = Animation(
+            spriteSheetNamed: "sheet2",
+            frameCount: 6,
+            rowCount: 2,
+            frameDuration: 1
+        )
+        newAnimation.textureScale = 1
+        actor.animation = newAnimation
+
+        game.update()
+        XCTAssertEqual(game.textureImageLoader.imageNames, ["sheet", "sheet2"])
     }
 
     func testTextureNamePrefix() {


### PR DESCRIPTION
This patch fixes a bug that would prevent an actor from updating a sprite sheet based animation, since it didn’t get an identifier assigned.