### PR TITLE
Action: Fix race condition when chaining multiple actions

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -101,6 +101,8 @@
 		527FC8061F8EB223006B1295 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527FC8051F8EB223006B1295 /* EventTests.swift */; };
 		527FC8081F8EB83F006B1295 /* CameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527FC8071F8EB83F006B1295 /* CameraTests.swift */; };
 		527FC80C1F8EBAAB006B1295 /* LabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527FC80B1F8EBAAB006B1295 /* LabelTests.swift */; };
+		528B21511FA382B300CE9967 /* UpdatableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B21501FA382B300CE9967 /* UpdatableCollection.swift */; };
+		528B21521FA382B300CE9967 /* UpdatableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B21501FA382B300CE9967 /* UpdatableCollection.swift */; };
 		52C860301F8E374100C6C7A7 /* ActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C8602D1F8E36B600C6C7A7 /* ActorTests.swift */; };
 		52C860361F8E383100C6C7A7 /* ImageMockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C860341F8E382800C6C7A7 /* ImageMockFactory.swift */; };
 		52C860381F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C860371F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift */; };
@@ -268,6 +270,7 @@
 		527FC8051F8EB223006B1295 /* EventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
 		527FC8071F8EB83F006B1295 /* CameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraTests.swift; sourceTree = "<group>"; };
 		527FC80B1F8EBAAB006B1295 /* LabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelTests.swift; sourceTree = "<group>"; };
+		528B21501FA382B300CE9967 /* UpdatableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatableCollection.swift; sourceTree = "<group>"; };
 		52C8602D1F8E36B600C6C7A7 /* ActorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActorTests.swift; sourceTree = "<group>"; };
 		52C860321F8E381600C6C7A7 /* Assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assert.swift; sourceTree = "<group>"; };
 		52C860331F8E381600C6C7A7 /* TimeTraveler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveler.swift; sourceTree = "<group>"; };
@@ -404,6 +407,7 @@
 				DD21B73B1F92E8B90034A7CE /* Screen-macOS.swift */,
 				522CD65F1F8D4512008DB43D /* TextLayer.swift */,
 				522CD6611F8D4512008DB43D /* Updatable.swift */,
+				528B21501FA382B300CE9967 /* UpdatableCollection.swift */,
 				522CD6621F8D4512008DB43D /* UpdatableWrapper.swift */,
 				522CD6631F8D4512008DB43D /* UpdateOutcome.swift */,
 				522CD6641F8D4512008DB43D /* View+MakeLayer.swift */,
@@ -749,6 +753,7 @@
 				522CD6991F8D4521008DB43D /* Layer.swift in Sources */,
 				522CD6981F8D4521008DB43D /* Grid.swift in Sources */,
 				522CD6921F8D4521008DB43D /* ClickPlugin.swift in Sources */,
+				528B21511FA382B300CE9967 /* UpdatableCollection.swift in Sources */,
 				522CD6971F8D4521008DB43D /* GameView.swift in Sources */,
 				522CD6911F8D4521008DB43D /* Activatable.swift in Sources */,
 				522CD67C1F8D451D008DB43D /* Group.swift in Sources */,
@@ -890,6 +895,7 @@
 				DD21B72B1F92E75A0034A7CE /* Constraint.swift in Sources */,
 				DD21B72C1F92E75A0034A7CE /* Typealiases.swift in Sources */,
 				DD21B72D1F92E75A0034A7CE /* DisplayLinkProtocol.swift in Sources */,
+				528B21521FA382B300CE9967 /* UpdatableCollection.swift in Sources */,
 				DD21B72E1F92E75A0034A7CE /* ReplicatorLayer.swift in Sources */,
 				DD21B72F1F92E75A0034A7CE /* RepeatMode.swift in Sources */,
 			);

--- a/Sources/Core/API/Timeline.swift
+++ b/Sources/Core/API/Timeline.swift
@@ -35,7 +35,7 @@ public final class Timeline: Activatable {
 
     private var rootNode: Node?
     private lazy var unsortedUpdatables = [(UpdatableWrapper, TimeInterval)]()
-    private lazy var immediateUpdatables = Set<UpdatableWrapper>()
+    private lazy var immediateUpdatables = UpdatableCollection()
     private var lastUpdateTime: TimeInterval?
     private var pauseInterval: TimeInterval = 0
 
@@ -79,10 +79,7 @@ public final class Timeline: Activatable {
         lastUpdateTime = currentTime
         let currentTime = currentTime - pauseInterval
 
-        let updatables = immediateUpdatables
-        immediateUpdatables = []
-
-        for updatable in updatables {
+        for updatable in immediateUpdatables.removeAll() {
             let outcome = updatable.update(currentTime: currentTime)
 
             switch outcome {
@@ -130,13 +127,13 @@ public final class Timeline: Activatable {
 private extension Timeline {
     final class Node {
         let time: TimeInterval
-        var updatables: Set<UpdatableWrapper>
+        var updatables = UpdatableCollection()
         var greaterChild: Node?
         var lesserChild: Node?
 
         init(time: TimeInterval, updatable: UpdatableWrapper) {
             self.time = time
-            self.updatables = [updatable]
+            updatables.insert(updatable)
         }
 
         func insert(_ updatable: UpdatableWrapper, at insertTime: TimeInterval) {
@@ -159,10 +156,7 @@ private extension Timeline {
 
         func update(in timeline: Timeline, currentTime: TimeInterval) -> NodeUpdateOutcome {
             if currentTime >= time {
-                let currentUpdatables = updatables
-                updatables = []
-
-                for updatable in currentUpdatables {
+                for updatable in updatables.removeAll() {
                     let outcome = updatable.update(currentTime: currentTime)
 
                     switch outcome {

--- a/Sources/Core/Internal/ActionWrapper.swift
+++ b/Sources/Core/Internal/ActionWrapper.swift
@@ -23,6 +23,19 @@ internal final class ActionWrapper<Object: AnyObject>: Updatable {
             return .finished
         }
 
+        guard !action.token.isCancelled else {
+            if isInProgress {
+                action.cancel(for: object)
+                reset()
+            }
+
+            return .finished
+        }
+
+        guard !action.token.isPending else {
+            return .continueAfter(0)
+        }
+
         if !isInProgress {
             isInProgress = true
             action.start(for: object)
@@ -30,16 +43,6 @@ internal final class ActionWrapper<Object: AnyObject>: Updatable {
             for linkedToken in action.token.linkedTokens {
                 linkedToken.isPending = false
             }
-        }
-
-        guard !action.token.isCancelled else {
-            action.cancel(for: object)
-            reset()
-            return .finished
-        }
-
-        guard !action.token.isPending else {
-            return .continueAfter(0)
         }
 
         let outcome = action.update(for: object, currentTime: currentTime)

--- a/Sources/Core/Internal/UpdatableCollection.swift
+++ b/Sources/Core/Internal/UpdatableCollection.swift
@@ -1,0 +1,31 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+
+internal struct UpdatableCollection {
+    var isEmpty: Bool { return objects.isEmpty }
+
+    private var identifiers = Set<ObjectIdentifier>()
+    private var objects = [UpdatableWrapper]()
+
+    mutating func insert(_ object: UpdatableWrapper) {
+        let identifier = ObjectIdentifier(object)
+
+        guard identifiers.insert(identifier).inserted else {
+            return
+        }
+
+        objects.append(object)
+    }
+
+    mutating func removeAll() -> [UpdatableWrapper] {
+        let allObjects = objects
+        objects = []
+        identifiers = []
+        return allObjects
+    }
+}

--- a/Sources/Core/Internal/UpdatableWrapper.swift
+++ b/Sources/Core/Internal/UpdatableWrapper.swift
@@ -24,11 +24,3 @@ internal final class UpdatableWrapper: Updatable {
         return updatable.update(currentTime: currentTime)
     }
 }
-
-extension UpdatableWrapper: Hashable {
-    static func ==(lhs: UpdatableWrapper, rhs: UpdatableWrapper) -> Bool {
-        return lhs.updatable === rhs.updatable
-    }
-
-    var hashValue: Int { return ObjectIdentifier(updatable).hashValue }
-}


### PR DESCRIPTION
This patch fixes a race condition that could cause a chained action not to be performed when multiple ones were chained together. The problem had two parts to it:

1. An action could be started even though it was pending or cancelled.

2. `Timeline` wouldn’t keep its updatables in order, and instead use a `Set`. This was fixed by introducing a custom collection wrapper that maintains the order of the updatables.