### PR TITLE
Camera: Enable constraining to scene

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -53,7 +53,7 @@ open class Scene: Activatable {
     public init(size: Size) {
         self.size = size
 
-        camera = Camera(layer: layer)
+        camera = Camera(layer: layer, sceneSize: size)
         camera.position = Point(x: size.width / 2, y: size.height / 2)
 
         sizeDidChange()
@@ -89,7 +89,7 @@ open class Scene: Activatable {
             remove(label)
         }
 
-        camera = Camera(layer: layer)
+        camera = Camera(layer: layer, sceneSize: size)
         camera.position = Point(x: size.width / 2, y: size.height / 2)
 
         events = SceneEventCollection(object: self)
@@ -259,6 +259,7 @@ open class Scene: Activatable {
 
     private func sizeDidChange() {
         layer.bounds.size = size
+        camera.sceneSize = size
     }
 
     private func backgroundColorDidChange() {

--- a/Tests/ImagineEngineTests/CameraTests.swift
+++ b/Tests/ImagineEngineTests/CameraTests.swift
@@ -46,6 +46,35 @@ final class CameraTests: XCTestCase {
         XCTAssertEqual(scene.camera.rect, Rect(x: 0, y: 0, width: 100, height: 200))
     }
 
+    func testConstrainingToScene() {
+        game.view.frame.size = Size(width: 500, height: 300)
+
+        let scene = Scene(size: Size(width: 500, height: 300))
+        game.scene = scene
+
+        // By default, the camera is not constrained to the scene and can move outside it
+        scene.camera.position = Point(x: -2000, y: -1000)
+        XCTAssertEqual(scene.camera.position, Point(x: -2000, y: -1000))
+
+        // When turning on the constraint, the camera should move within the scene
+        scene.camera.constrainedToScene = true
+        XCTAssertEqual(scene.camera.position, Point(x: 250, y: 150))
+
+        // From now on the camera shouldn't be able to move outside of the scene
+        scene.camera.position.x += 100
+        scene.camera.position.y += 100
+        XCTAssertEqual(scene.camera.position, Point(x: 250, y: 150))
+
+        scene.camera.position.x -= 100
+        scene.camera.position.y -= 100
+        XCTAssertEqual(scene.camera.position, Point(x: 250, y: 150))
+
+        // If the scene becomes smaller than the viewport, constraints are no longer evaluated
+        scene.size = Size(width: 100, height: 200)
+        scene.camera.position = Point(x: -2000, y: -1000)
+        XCTAssertEqual(scene.camera.position, Point(x: -2000, y: -1000))
+    }
+
     func testAddingAndRemovingPlugin() {
         let plugin = PluginMock<Camera>()
 


### PR DESCRIPTION
This change adds a new property on camera that lets it be constrained to its scene, meaning that it can not move outside of it. The default is false, which matches the current behavior.