### PR TITLE
Actor: Combine move events & remove duplicates

### DIFF
--- a/Sources/Core/API/ActorEventCollection.swift
+++ b/Sources/Core/API/ActorEventCollection.swift
@@ -8,10 +8,8 @@ import Foundation
 
 /// Events that can be used to observe an actor
 public final class ActorEventCollection: EventCollection<Actor> {
-    /// Event triggered when the actor is about to move (contains the new position)
-    public private(set) lazy var willMove = Event<Actor, Point>(object: self.object)
     /// Event triggered when the actor was moved
-    public private(set) lazy var moved = Event<Actor, Void>(object: self.object)
+    public private(set) lazy var moved = Event<Actor, (old: Point, new: Point)>(object: self.object)
     /// Event triggered when the actor was resized
     public private(set) lazy var resized = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor's rectangle changed (either by position or size)

--- a/Tests/ImagineEngineTests/EventTests.swift
+++ b/Tests/ImagineEngineTests/EventTests.swift
@@ -43,19 +43,19 @@ final class EventTests: XCTestCase {
         var passedActor: Actor?
         var triggerCount = 0
 
-        actor.events.moved.addObserver(observer) {
+        actor.events.resized.addObserver(observer) {
             passedObserver = $0
             passedActor = $1
             triggerCount += 1
         }
 
-        actor.events.moved.trigger()
+        actor.events.resized.trigger()
         assertSameInstance(passedObserver, observer)
         assertSameInstance(passedActor, actor)
         XCTAssertEqual(triggerCount, 1)
 
-        actor.events.moved.removeObserver(observer)
-        actor.events.moved.trigger()
+        actor.events.resized.removeObserver(observer)
+        actor.events.resized.trigger()
         XCTAssertEqual(triggerCount, 1)
     }
 
@@ -66,17 +66,17 @@ final class EventTests: XCTestCase {
         let actor = Actor()
         var triggerCount = 0
 
-        actor.events.moved.addObserver(observer!) { _ in
+        actor.events.resized.addObserver(observer!) { _ in
             triggerCount += 1
         }
 
-        actor.events.moved.trigger()
+        actor.events.resized.trigger()
         XCTAssertEqual(triggerCount, 1)
 
         observer = nil
         XCTAssertNil(weakObserver)
 
-        actor.events.moved.trigger()
+        actor.events.resized.trigger()
         XCTAssertEqual(triggerCount, 1)
     }
 


### PR DESCRIPTION
This fix merges the previously introduced `willMove` event into the `move` event and makes it include a tuple with both the old and new positions as its value. This enables logic that uses either the old or new position to use the exact same event.

Further, a fix has been made to not send duplicate events when a position is corrected by, for example, constraints. Only the final position is now emitted as an event, if it differs from the original.