### PR TITLE
Implement remembering texture scale fallbacks

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -111,8 +111,8 @@
 		52D6D9871BEFF229002C0205 /* ImagineEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* ImagineEngine.framework */; };
 		C86A78BE1FA1B61A0099632B /* TextureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */; };
 		C86A78BF1FA1B61A0099632B /* TextureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */; };
-		C8D2FCE51FA493940077B560 /* BundleImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */; };
-		C8D2FCE61FA493940077B560 /* BundleImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */; };
+		C8D2FCE51FA493940077B560 /* BundleTextureImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */; };
+		C8D2FCE61FA493940077B560 /* BundleTextureImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */; };
 		DD21B6F21F92E75A0034A7CE /* View+MakeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6641F8D4512008DB43D /* View+MakeLayer.swift */; };
 		DD21B6F31F92E75A0034A7CE /* PluginWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD65D1F8D4512008DB43D /* PluginWrapper.swift */; };
 		DD21B6F41F92E75A0034A7CE /* Scalable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6471F8D4512008DB43D /* Scalable.swift */; };
@@ -285,7 +285,7 @@
 		AD2FAA261CD0B6D800659CF4 /* ImagineEngine.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ImagineEngine.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* ImagineEngineTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ImagineEngineTests.plist; sourceTree = "<group>"; };
 		C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureManagerTests.swift; sourceTree = "<group>"; };
-		C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleImageLoader.swift; sourceTree = "<group>"; };
+		C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTextureImageLoader.swift; sourceTree = "<group>"; };
 		DD21B7361F92E75A0034A7CE /* ImagineEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ImagineEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD21B7381F92E81C0034A7CE /* Image-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image-macOS.swift"; sourceTree = "<group>"; };
 		DD21B73B1F92E8B90034A7CE /* Screen-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Screen-macOS.swift"; sourceTree = "<group>"; };
@@ -391,7 +391,7 @@
 				522CD64F1F8D4512008DB43D /* ActionManager.swift */,
 				522CD6501F8D4512008DB43D /* ActionWrapper.swift */,
 				522CD6511F8D4512008DB43D /* Activatable.swift */,
-				C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */,
+				C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */,
 				5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */,
 				522CD6521F8D4512008DB43D /* ClickPlugin.swift */,
 				522CD6531F8D4512008DB43D /* ClosureUpdatable.swift */,
@@ -767,7 +767,7 @@
 				522CD6731F8D451D008DB43D /* CancellationToken.swift in Sources */,
 				522CD68A1F8D451D008DB43D /* Scene.swift in Sources */,
 				52479F801F8E58E200D22A87 /* TextureImageLoader.swift in Sources */,
-				C8D2FCE51FA493940077B560 /* BundleImageLoader.swift in Sources */,
+				C8D2FCE51FA493940077B560 /* BundleTextureImageLoader.swift in Sources */,
 				522CD68F1F8D4521008DB43D /* ActionManager.swift in Sources */,
 				522CD68B1F8D451D008DB43D /* SceneEventCollection.swift in Sources */,
 				522CD6901F8D4521008DB43D /* ActionWrapper.swift in Sources */,
@@ -847,7 +847,7 @@
 				DD21B6F81F92E75A0034A7CE /* Optional+GetOrSet.swift in Sources */,
 				DD21B6F91F92E75A0034A7CE /* ClosureAction.swift in Sources */,
 				DD21B6FA1F92E75A0034A7CE /* RepeatAction.swift in Sources */,
-				C8D2FCE61FA493940077B560 /* BundleImageLoader.swift in Sources */,
+				C8D2FCE61FA493940077B560 /* BundleTextureImageLoader.swift in Sources */,
 				DD21B6FB1F92E75A0034A7CE /* ClosureUpdatable.swift in Sources */,
 				DD21B74B1F92ED6B0034A7CE /* GameWindowController.swift in Sources */,
 				DD21B6FC1F92E75A0034A7CE /* LoadedTexture.swift in Sources */,

--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		52D6D9871BEFF229002C0205 /* ImagineEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* ImagineEngine.framework */; };
 		C86A78BE1FA1B61A0099632B /* TextureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */; };
 		C86A78BF1FA1B61A0099632B /* TextureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */; };
+		C8D2FCE51FA493940077B560 /* BundleImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */; };
+		C8D2FCE61FA493940077B560 /* BundleImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */; };
 		DD21B6F21F92E75A0034A7CE /* View+MakeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6641F8D4512008DB43D /* View+MakeLayer.swift */; };
 		DD21B6F31F92E75A0034A7CE /* PluginWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD65D1F8D4512008DB43D /* PluginWrapper.swift */; };
 		DD21B6F41F92E75A0034A7CE /* Scalable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6471F8D4512008DB43D /* Scalable.swift */; };
@@ -283,6 +285,7 @@
 		AD2FAA261CD0B6D800659CF4 /* ImagineEngine.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ImagineEngine.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* ImagineEngineTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ImagineEngineTests.plist; sourceTree = "<group>"; };
 		C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureManagerTests.swift; sourceTree = "<group>"; };
+		C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleImageLoader.swift; sourceTree = "<group>"; };
 		DD21B7361F92E75A0034A7CE /* ImagineEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ImagineEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD21B7381F92E81C0034A7CE /* Image-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image-macOS.swift"; sourceTree = "<group>"; };
 		DD21B73B1F92E8B90034A7CE /* Screen-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Screen-macOS.swift"; sourceTree = "<group>"; };
@@ -388,12 +391,13 @@
 				522CD64F1F8D4512008DB43D /* ActionManager.swift */,
 				522CD6501F8D4512008DB43D /* ActionWrapper.swift */,
 				522CD6511F8D4512008DB43D /* Activatable.swift */,
+				C8D2FCE41FA493940077B560 /* BundleImageLoader.swift */,
 				5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */,
 				522CD6521F8D4512008DB43D /* ClickPlugin.swift */,
 				522CD6531F8D4512008DB43D /* ClosureUpdatable.swift */,
-				52C860371F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift */,
 				522CD6541F8D4512008DB43D /* DisplayLink-iOS+tvOS.swift */,
 				DD21B7421F92EB140034A7CE /* DisplayLink-macOS.swift */,
+				52C860371F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift */,
 				522CD6571F8D4512008DB43D /* GameView.swift */,
 				522CD6581F8D4512008DB43D /* Grid.swift */,
 				DD21B7381F92E81C0034A7CE /* Image-macOS.swift */,
@@ -763,6 +767,7 @@
 				522CD6731F8D451D008DB43D /* CancellationToken.swift in Sources */,
 				522CD68A1F8D451D008DB43D /* Scene.swift in Sources */,
 				52479F801F8E58E200D22A87 /* TextureImageLoader.swift in Sources */,
+				C8D2FCE51FA493940077B560 /* BundleImageLoader.swift in Sources */,
 				522CD68F1F8D4521008DB43D /* ActionManager.swift in Sources */,
 				522CD68B1F8D451D008DB43D /* SceneEventCollection.swift in Sources */,
 				522CD6901F8D4521008DB43D /* ActionWrapper.swift in Sources */,
@@ -842,6 +847,7 @@
 				DD21B6F81F92E75A0034A7CE /* Optional+GetOrSet.swift in Sources */,
 				DD21B6F91F92E75A0034A7CE /* ClosureAction.swift in Sources */,
 				DD21B6FA1F92E75A0034A7CE /* RepeatAction.swift in Sources */,
+				C8D2FCE61FA493940077B560 /* BundleImageLoader.swift in Sources */,
 				DD21B6FB1F92E75A0034A7CE /* ClosureUpdatable.swift in Sources */,
 				DD21B74B1F92ED6B0034A7CE /* GameWindowController.swift in Sources */,
 				DD21B6FC1F92E75A0034A7CE /* LoadedTexture.swift in Sources */,
@@ -925,10 +931,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = TEE39J9D8F;
+				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Configs/ImagineEngineTests.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -949,10 +955,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = TEE39J9D8F;
+				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Configs/ImagineEngineTests.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/Sources/Core/API/TextureImageLoader.swift
+++ b/Sources/Core/API/TextureImageLoader.swift
@@ -8,6 +8,6 @@ import CoreGraphics
  *  to integrate such a pipeline with an instance of `TextureManager`.
  */
 public protocol TextureImageLoader {
-    /// Load an image for a texture with a given name
-    func loadImageForTexture(named name: String) -> CGImage?
+    /// Load an image for a texture with a given name and scale
+    func loadImageForTexture(named name: String, scale: Int) -> CGImage?
 }

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -36,10 +36,6 @@ public final class TextureManager {
         let scale = scale ?? defaultScale
         var name = texture.name
 
-        if scale > 1 {
-            name.append("@\(scale)x")
-        }
-
         if let prefix = namePrefix {
             name = "\(prefix)\(name)"
         }
@@ -57,7 +53,7 @@ public final class TextureManager {
             return texture
         }
 
-        guard let image = imageLoader.loadImageForTexture(named: name) else {
+        guard let image = imageLoader.loadImageForTexture(named: name, scale: scale) else {
             guard scale > 1 else {
                 return nil
             }

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -10,17 +10,16 @@ import CoreGraphics
 /// Class that manages & faciliates the loading of textures for actors
 public final class TextureManager {
     /// Any custom image loader that should be used (nil = load from bundle)
-    public var imageLoader: TextureImageLoader?
+    public var imageLoader: TextureImageLoader
     /// The default scale when loading textures (default = the main screen's scale)
     public var defaultScale: Int = Int(Screen.mainScreenScale)
 
     internal private(set) var cache = [String : LoadedTexture]()
-    private let bundle: Bundle
 
     // MARK: - Init
 
-    internal init(bundle: Bundle = .main) {
-        self.bundle = bundle
+    internal init(imageLoader: TextureImageLoader = BundleImageLoader()) {
+        self.imageLoader = imageLoader
     }
 
     // MARK: - Public
@@ -58,7 +57,7 @@ public final class TextureManager {
             return texture
         }
 
-        guard let image = loadImage(named: name) else {
+        guard let image = imageLoader.loadImageForTexture(named: name) else {
             guard scale > 1 else {
                 return nil
             }
@@ -68,30 +67,5 @@ public final class TextureManager {
         let texture = LoadedTexture(image: image, scale: scale)
         cache[name] = texture
         return texture
-    }
-
-    // MARK: - Private
-
-    private func loadImage(named name: String) -> CGImage? {
-        if let imageLoader = imageLoader {
-            return imageLoader.loadImageForTexture(named: name)
-        }
-
-        guard let url = bundle.url(forResource: name, withExtension: "png") else {
-            return nil
-        }
-
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
-
-        guard let dataProvider = CGDataProvider(data: data as CFData) else {
-            return nil
-        }
-
-        return CGImage(pngDataProviderSource: dataProvider,
-                       decode: nil,
-                       shouldInterpolate: false,
-                       intent: .defaultIntent)
     }
 }

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -18,7 +18,7 @@ public final class TextureManager {
 
     // MARK: - Init
 
-    internal init(imageLoader: TextureImageLoader = BundleImageLoader()) {
+    internal init(imageLoader: TextureImageLoader = BundleTextureImageLoader()) {
         self.imageLoader = imageLoader
     }
 

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -9,7 +9,7 @@ import CoreGraphics
 
 /// Class that manages & faciliates the loading of textures for actors
 public final class TextureManager {
-    /// Any custom image loader that should be used (nil = load from bundle)
+    /// The image loader that should be used (default = load from bundle)
     public var imageLoader: TextureImageLoader
     /// The default scale when loading textures (default = the main screen's scale)
     public var defaultScale: Int = Int(Screen.mainScreenScale)

--- a/Sources/Core/Internal/BundleImageLoader.swift
+++ b/Sources/Core/Internal/BundleImageLoader.swift
@@ -14,8 +14,14 @@ class BundleImageLoader: TextureImageLoader {
         self.bundle = bundle
     }
 
-    func loadImageForTexture(named name: String) -> CGImage? {
-        guard let url = bundle.url(forResource: name, withExtension: "png") else {
+    func loadImageForTexture(named name: String, scale: Int) -> CGImage? {
+        var imageName = name
+
+        if scale > 1 {
+            imageName.append("@\(scale)x")
+        }
+
+        guard let url = bundle.url(forResource: imageName, withExtension: "png") else {
             return nil
         }
 

--- a/Sources/Core/Internal/BundleImageLoader.swift
+++ b/Sources/Core/Internal/BundleImageLoader.swift
@@ -1,0 +1,35 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+import CoreGraphics
+
+class BundleImageLoader: TextureImageLoader {
+    let bundle: Bundle
+
+    init(bundle: Bundle = .main) {
+        self.bundle = bundle
+    }
+
+    func loadImageForTexture(named name: String) -> CGImage? {
+        guard let url = bundle.url(forResource: name, withExtension: "png") else {
+            return nil
+        }
+
+        guard let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+
+        guard let dataProvider = CGDataProvider(data: data as CFData) else {
+            return nil
+        }
+
+        return CGImage(pngDataProviderSource: dataProvider,
+                       decode: nil,
+                       shouldInterpolate: false,
+                       intent: .defaultIntent)
+    }
+}

--- a/Sources/Core/Internal/BundleTextureImageLoader.swift
+++ b/Sources/Core/Internal/BundleTextureImageLoader.swift
@@ -7,8 +7,8 @@
 import Foundation
 import CoreGraphics
 
-class BundleImageLoader: TextureImageLoader {
-    let bundle: Bundle
+internal final class BundleTextureImageLoader: TextureImageLoader {
+    private let bundle: Bundle
 
     init(bundle: Bundle = .main) {
         self.bundle = bundle

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -40,7 +40,7 @@ final class ActorTests: XCTestCase {
             Size(width: 100, height: 90)
         ]
 
-        let images = imageSizes.map(ImagineMockFactory.makeImage)
+        let images = imageSizes.map(ImageMockFactory.makeImage)
         actor.animation = Animation(images: images, frameDuration: 1.5)
 
         // The actor should directly render the first frame
@@ -67,7 +67,7 @@ final class ActorTests: XCTestCase {
 
     func testSettingActorInitialSizeFromAnimation() {
         let imageSize = Size(width: 200, height: 150)
-        let image = ImagineMockFactory.makeImage(withSize: imageSize)
+        let image = ImageMockFactory.makeImage(withSize: imageSize)
 
         let actor = Actor()
         actor.animation = Animation(image: image)
@@ -82,7 +82,7 @@ final class ActorTests: XCTestCase {
 
     func testAnimatingWithSpriteSheet() {
         let imageSize = Size(width: 300, height: 100)
-        let image = ImagineMockFactory.makeImage(withSize: imageSize)
+        let image = ImageMockFactory.makeImage(withSize: imageSize)
         game.textureImageLoader.images["sheet"] = image.cgImage
 
         var animation = Animation(

--- a/Tests/ImagineEngineTests/Mocks/TextureImageLoaderMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/TextureImageLoaderMock.swift
@@ -12,8 +12,20 @@ final class TextureImageLoaderMock: TextureImageLoader {
     private(set) var imageNames = Set<String>()
     var images = [String : CGImage]()
 
-    func loadImageForTexture(named name: String) -> CGImage? {
+    func loadImageForTexture(named name: String, scale: Int) -> CGImage? {
+        let name = imageName(name, withScale: scale)
         imageNames.insert(name)
         return images[name]
+    }
+
+    func clearImageNames() {
+        imageNames.removeAll()
+    }
+
+    private func imageName(_ name: String, withScale scale: Int) -> String {
+        guard scale > 1 else {
+            return name
+        }
+        return "\(name)@\(scale)x"
     }
 }

--- a/Tests/ImagineEngineTests/TextureManagerTests.swift
+++ b/Tests/ImagineEngineTests/TextureManagerTests.swift
@@ -9,8 +9,8 @@ import XCTest
 @testable import ImagineEngine
 
 class TextureManagerTests: XCTestCase {
-    var manager: TextureManager!
-    var imageLoader: TextureImageLoaderMock!
+    private var manager: TextureManager!
+    private var imageLoader: TextureImageLoaderMock!
 
     override func setUp() {
         manager = TextureManager()

--- a/Tests/ImagineEngineTests/TextureManagerTests.swift
+++ b/Tests/ImagineEngineTests/TextureManagerTests.swift
@@ -9,15 +9,34 @@ import XCTest
 @testable import ImagineEngine
 
 class TextureManagerTests: XCTestCase {
-    func testFallsBackToLowerScaleTextures() {
-        let imageLoader = TextureImageLoaderMock()
-        let manager = TextureManager()
-        manager.imageLoader = imageLoader
+    var manager: TextureManager!
+    var imageLoader: TextureImageLoaderMock!
 
+    override func setUp() {
+        manager = TextureManager()
+        imageLoader = TextureImageLoaderMock()
+        manager.imageLoader = imageLoader
+    }
+
+    func testFallsBackToLowerScaleTextures() {
         _ = manager.load(Texture(name: "texture"), namePrefix: nil, scale: 3)
 
-        XCTAssert(imageLoader.imageNames.contains("texture@3x"))
-        XCTAssert(imageLoader.imageNames.contains("texture@2x"))
-        XCTAssert(imageLoader.imageNames.contains("texture"))
+        XCTAssertEqual(imageLoader.imageNames, ["texture@3x", "texture@2x", "texture"])
+    }
+
+    func testRemembersTextureScaleFallback() {
+        imageLoader.images["texture@2x"] = makeImage()
+
+        _ = manager.load(Texture(name: "texture"), namePrefix: nil, scale: 3)
+        XCTAssertEqual(imageLoader.imageNames, ["texture@3x", "texture@2x"])
+
+        imageLoader.clearImageNames()
+
+        _ = manager.load(Texture(name: "texture"), namePrefix: nil, scale: 3)
+        XCTAssert(imageLoader.imageNames.isEmpty)
+    }
+
+    private func makeImage() -> CGImage {
+        return ImageMockFactory.makeCGImage(withSize: Size(width: 1, height: 1))
     }
 }

--- a/Tests/ImagineEngineTests/Utilities/ImageMockFactory.swift
+++ b/Tests/ImagineEngineTests/Utilities/ImageMockFactory.swift
@@ -8,8 +8,12 @@ import Foundation
 import CoreGraphics
 @testable import ImagineEngine
 
-final class ImagineMockFactory {
+final class ImageMockFactory {
     static func makeImage(withSize size: Size) -> Image {
+        return Image(cgImage: ImageMockFactory.makeCGImage(withSize: size))
+    }
+
+    static func makeCGImage(withSize size: Size) -> CGImage {
         let context = CGContext(
             data: nil,
             width: Int(size.width),
@@ -19,7 +23,6 @@ final class ImagineMockFactory {
             space: CGColorSpaceCreateDeviceRGB(),
             bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
         )!
-
-        return Image(cgImage: context.makeImage()!)
+        return context.makeImage()!
     }
 }


### PR DESCRIPTION
This PR resolves #16.

The main idea here is to cache images without adding scale to the cache key.

Another thing is to move `scale` param right into `TextureImageLoader` protocol method, because different image loading pipelines may have different ways of obtaining correct scales of the image (and it feels right to move this logic out of `TextureManager`).

Also provided couple more refactorings around `TextureManager`: extracted bundle image loading to `BundleImageLoader` that conforms to `TextureImageLoader` protocol.