### PR TITLE
Modernize lazy var declarations

### DIFF
--- a/Sources/Core/API/ActorEventCollection.swift
+++ b/Sources/Core/API/ActorEventCollection.swift
@@ -23,7 +23,7 @@ public final class ActorEventCollection: EventCollection<Actor> {
     /// Event triggered when the actor exited its scene
     public private(set) lazy var leftScene = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor was clicked (on macOS) or tapped (on iOS/tvOS)
-    public private(set) lazy var clicked: Event<Actor, Void> = self.makeClickedEvent()
+    public private(set) lazy var clicked = makeClickedEvent()
 
     /// Event triggered when the actor collided with another actor
     public func collided(with actor: Actor) -> Event<Actor, Actor> {

--- a/Sources/Core/API/SceneEventCollection.swift
+++ b/Sources/Core/API/SceneEventCollection.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Events that can be used to observe a scene
 public final class SceneEventCollection: EventCollection<Scene> {
     /// Event that will be triggered when the scene was clicked or tapped
-    public private(set) lazy var clicked: Event<Scene, Point> = self.makeClickedEvent()
+    public private(set) lazy var clicked = makeClickedEvent()
 
     private func makeClickedEvent() -> Event<Scene, Point> {
         object?.add(ClickPlugin())

--- a/Sources/Core/Internal/DisplayLink-iOS+tvOS.swift
+++ b/Sources/Core/Internal/DisplayLink-iOS+tvOS.swift
@@ -9,7 +9,7 @@ import QuartzCore
 
 internal final class DisplayLink: DisplayLinkProtocol {
     var callback: () -> Void = {}
-    private lazy var link: CADisplayLink = self.makeLink()
+    private lazy var link = makeLink()
 
     deinit {
         link.remove(from: .main, forMode: .commonModes)


### PR DESCRIPTION
A simple change to remove type annotations and `self` references from lazy property declarations, since they are no longer required in Swift 4.