### PR TITLE
Plugins: Return existing instance when adding a plugin

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -190,6 +190,9 @@
 		527FC80C1F8EBAAB006B1295 /* LabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527FC80B1F8EBAAB006B1295 /* LabelTests.swift */; };
 		528B21511FA382B300CE9967 /* UpdatableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B21501FA382B300CE9967 /* UpdatableCollection.swift */; };
 		528B21521FA382B300CE9967 /* UpdatableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B21501FA382B300CE9967 /* UpdatableCollection.swift */; };
+		52A124D31FABA8AB00252047 /* Pluggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A124D21FABA8AB00252047 /* Pluggable.swift */; };
+		52A124D41FABA8AB00252047 /* Pluggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A124D21FABA8AB00252047 /* Pluggable.swift */; };
+		52A124D51FABA8AB00252047 /* Pluggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A124D21FABA8AB00252047 /* Pluggable.swift */; };
 		52C860301F8E374100C6C7A7 /* ActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C8602D1F8E36B600C6C7A7 /* ActorTests.swift */; };
 		52C860361F8E383100C6C7A7 /* ImageMockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C860341F8E382800C6C7A7 /* ImageMockFactory.swift */; };
 		52C860381F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C860371F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift */; };
@@ -390,6 +393,7 @@
 		527FC8071F8EB83F006B1295 /* CameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraTests.swift; sourceTree = "<group>"; };
 		527FC80B1F8EBAAB006B1295 /* LabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelTests.swift; sourceTree = "<group>"; };
 		528B21501FA382B300CE9967 /* UpdatableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatableCollection.swift; sourceTree = "<group>"; };
+		52A124D21FABA8AB00252047 /* Pluggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pluggable.swift; sourceTree = "<group>"; };
 		52C8602D1F8E36B600C6C7A7 /* ActorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActorTests.swift; sourceTree = "<group>"; };
 		52C860321F8E381600C6C7A7 /* Assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assert.swift; sourceTree = "<group>"; };
 		52C860331F8E381600C6C7A7 /* TimeTraveler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveler.swift; sourceTree = "<group>"; };
@@ -513,6 +517,7 @@
 				522CD6481F8D4512008DB43D /* ScaleAction.swift */,
 				522CD6491F8D4512008DB43D /* Scene.swift */,
 				522CD64A1F8D4512008DB43D /* SceneEventCollection.swift */,
+				52A124D21FABA8AB00252047 /* Pluggable.swift */,
 				523E5D0F1F9FEFBC0084792C /* SpriteSheet.swift */,
 				522CD64B1F8D4512008DB43D /* Texture.swift */,
 				C800CE2F1FA782EA008EE08D /* TextureFormat.swift */,
@@ -965,6 +970,7 @@
 				5253C7D01FA4D57200D304B5 /* Rotatable.swift in Sources */,
 				5253C79B1FA4D54000D304B5 /* GameViewController-iOS+tvOS.swift in Sources */,
 				C80942701FA79925002B42A6 /* TextureFormat.swift in Sources */,
+				52A124D51FABA8AB00252047 /* Pluggable.swift in Sources */,
 				5253C7B61FA4D57200D304B5 /* Actor.swift in Sources */,
 				5253C7A01FA4D56C00D304B5 /* ClickPlugin.swift in Sources */,
 				5253C7C01FA4D57200D304B5 /* Event.swift in Sources */,
@@ -1067,6 +1073,7 @@
 				522CD6811F8D451D008DB43D /* Movable.swift in Sources */,
 				522CD69B1F8D4521008DB43D /* Optional+GetOrSet.swift in Sources */,
 				C800CE301FA782EA008EE08D /* TextureFormat.swift in Sources */,
+				52A124D31FABA8AB00252047 /* Pluggable.swift in Sources */,
 				522CD6741F8D451D008DB43D /* ClosureAction.swift in Sources */,
 				522CD6841F8D451D008DB43D /* RepeatAction.swift in Sources */,
 				522CD6931F8D4521008DB43D /* ClosureUpdatable.swift in Sources */,
@@ -1189,6 +1196,7 @@
 				DD21B73D1F92E8CB0034A7CE /* Screen-macOS.swift in Sources */,
 				5253C7DE1FA4D7E400D304B5 /* Font+Default.swift in Sources */,
 				DD21B7061F92E75A0034A7CE /* Label.swift in Sources */,
+				52A124D41FABA8AB00252047 /* Pluggable.swift in Sources */,
 				DD21B7071F92E75A0034A7CE /* UpdatableWrapper.swift in Sources */,
 				DD21B7081F92E75A0034A7CE /* CancellationToken.swift in Sources */,
 				DD21B7091F92E75A0034A7CE /* Scene.swift in Sources */,

--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -26,7 +26,7 @@ import Foundation
  *  scene.add(actor)
  *  ```
  */
-public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movable, Rotatable, Scalable, Fadeable {
+public final class Actor: InstanceHashable, ActionPerformer, Pluggable, Activatable, Movable, Rotatable, Scalable, Fadeable {
     /// The scene that the actor currently belongs to.
     public internal(set) weak var scene: Scene? { didSet { sceneDidChange() } }
     /// A collection of events that can be used to observe the actor.
@@ -89,6 +89,17 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
         return actionManager.add(action)
     }
 
+    // MARK: - Pluggable
+
+    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P,
+                                                  reuseExistingOfSameType: Bool) -> P where P.Object == Actor {
+        return pluginManager.add(plugin, for: self, reuseExistingOfSameType: reuseExistingOfSameType)
+    }
+
+    public func remove<P: Plugin>(_ plugin: P) where P.Object == Actor {
+        pluginManager.remove(plugin, from: self)
+    }
+
     // MARK: - Activatable
 
     internal func activate(in game: Game) {
@@ -100,16 +111,6 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
         scene = nil
         pluginManager.deactivate()
         actionManager.deactivate()
-    }
-
-    // MARK: - Public
-
-    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == Actor {
-        return pluginManager.add(plugin, for: self)
-    }
-
-    public func remove<P: Plugin>(_ plugin: P) where P.Object == Actor {
-        pluginManager.remove(plugin, from: self)
     }
 
     /// Remove this actor from its scene

--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -104,8 +104,8 @@ public final class Actor: InstanceHashable, ActionPerformer, Activatable, Movabl
 
     // MARK: - Public
 
-    public func add<P: Plugin>(_ plugin: @autoclosure () -> P) where P.Object == Actor {
-        pluginManager.add(plugin, for: self)
+    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == Actor {
+        return pluginManager.add(plugin, for: self)
     }
 
     public func remove<P: Plugin>(_ plugin: P) where P.Object == Actor {

--- a/Sources/Core/API/Camera.swift
+++ b/Sources/Core/API/Camera.swift
@@ -39,8 +39,8 @@ public final class Camera: ActionPerformer, Movable, Activatable {
 
     // MARK: - Plugin API
 
-    public func add<P: Plugin>(_ plugin: @autoclosure () -> P) where P.Object == Camera {
-        pluginManager.add(plugin, for: self)
+    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == Camera {
+        return pluginManager.add(plugin, for: self)
     }
 
     public func remove<P: Plugin>(_ plugin: P) where P.Object == Camera {

--- a/Sources/Core/API/Camera.swift
+++ b/Sources/Core/API/Camera.swift
@@ -13,7 +13,7 @@ import Foundation
  *  all cameras start out at the center of their scene. A camera gets its size
  *  from the game that its scene is presented in.
  */
-public final class Camera: ActionPerformer, Movable, Activatable {
+public final class Camera: ActionPerformer, Pluggable, Movable, Activatable {
     /// The position of the camera within its scene
     public var position = Point() { didSet { positionDidChange(from: oldValue) } }
     /// The size of the camera's viewport. Set as soon as its presented in a game.
@@ -37,20 +37,21 @@ public final class Camera: ActionPerformer, Movable, Activatable {
         self.sceneSize = sceneSize
     }
 
-    // MARK: - Plugin API
-
-    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == Camera {
-        return pluginManager.add(plugin, for: self)
-    }
-
-    public func remove<P: Plugin>(_ plugin: P) where P.Object == Camera {
-        pluginManager.remove(plugin, from: self)
-    }
-
     // MARK: - ActionPerformer
 
     @discardableResult public func perform(_ action: Action<Camera>) -> ActionToken {
         return actionManager.add(action)
+    }
+
+    // MARK: - Pluggable
+
+    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P,
+                                                  reuseExistingOfSameType: Bool) -> P where P.Object == Camera {
+        return pluginManager.add(plugin, for: self, reuseExistingOfSameType: reuseExistingOfSameType)
+    }
+
+    public func remove<P: Plugin>(_ plugin: P) where P.Object == Camera {
+        pluginManager.remove(plugin, from: self)
     }
 
     // MARK: - Activatable

--- a/Sources/Core/API/Pluggable.swift
+++ b/Sources/Core/API/Pluggable.swift
@@ -1,0 +1,34 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+
+/**
+ *  Protocol adopted by types that can be extended using plugins
+ *
+ *  Imagine Engine enables you to extend the functionality of several kinds of
+ *  objects through Plugins (see the `Plugin` protocol for more info). This lets
+ *  you easily decouple your game logic and share code between projects.
+ */
+public protocol Pluggable: class {
+    /// The target of the plugin, usually the object iself
+    associatedtype PluginTarget = Self
+
+    /// Add a plugin to this object or reuse an existing instance of the same type (default)
+    /// - Returns: The plugin that was either added or reused
+    func add<P: Plugin>(_ plugin: @autoclosure () -> P, reuseExistingOfSameType: Bool) -> P where P.Object == PluginTarget
+
+    /// Remove a plugin from this object
+    func remove<P: Plugin>(_ plugin: P) where P.Object == PluginTarget
+}
+
+public extension Pluggable {
+    /// Add a plugin to this object, reusing an existing instance of the same type if possible
+    /// - Returns: The plugin that was either added or reused
+    @discardableResult func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == PluginTarget {
+        return add(plugin, reuseExistingOfSameType: true)
+    }
+}

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -19,7 +19,7 @@ import Foundation
  *  You can also choose to subclass this class to add your own properties
  *  to keep track of your game's state.
  */
-open class Scene: Activatable {
+open class Scene: Pluggable, Activatable {
     /// The game that the scene currently belongs to.
     public private(set) var game: Game?
     /// The scene's camera. Can be used to move the visible area of the scene.
@@ -174,14 +174,13 @@ open class Scene: Activatable {
         grid.remove(label)
     }
 
-    // MARK: - Plugin API
+    // MARK: - Pluggable
 
-    /// Add a plugin to the scene
-    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == Scene {
-        return pluginManager.add(plugin, for: self)
+    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P,
+                                                  reuseExistingOfSameType: Bool) -> P where P.Object == Scene {
+        return pluginManager.add(plugin, for: self, reuseExistingOfSameType: reuseExistingOfSameType)
     }
 
-    /// Remove a plugin from the scene
     public func remove<P: Plugin>(_ plugin: P) where P.Object == Scene {
         pluginManager.remove(plugin, from: self)
     }

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -177,8 +177,8 @@ open class Scene: Activatable {
     // MARK: - Plugin API
 
     /// Add a plugin to the scene
-    public func add<P: Plugin>(_ plugin: @autoclosure () -> P) where P.Object == Scene {
-        pluginManager.add(plugin, for: self)
+    @discardableResult public func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == Scene {
+        return pluginManager.add(plugin, for: self)
     }
 
     /// Remove a plugin from the scene

--- a/Sources/Core/Internal/PluginManager.swift
+++ b/Sources/Core/Internal/PluginManager.swift
@@ -12,16 +12,19 @@ internal final class PluginManager: Activatable {
 
     // MARK: - API
 
-    func add<P: Plugin>(_ pluginProvider: () -> P, for object: P.Object) {
+    func add<P: Plugin>(_ pluginProvider: () -> P, for object: P.Object) -> P {
         let identifier = ObjectIdentifier(P.self)
 
-        guard plugins[identifier] == nil else {
-            return
+        if let existingPlugin = plugins[identifier] {
+            return existingPlugin.wrapped as! P
         }
 
-        let wrapper = PluginWrapper(plugin: pluginProvider(), object: object)
+        let plugin = pluginProvider()
+        let wrapper = PluginWrapper(plugin: plugin, object: object)
         plugins[identifier] = wrapper
         game.map(wrapper.activate)
+
+        return plugin
     }
 
     func remove<P: Plugin>(_ plugin: P, from object: P.Object) {

--- a/Sources/Core/Internal/PluginManager.swift
+++ b/Sources/Core/Internal/PluginManager.swift
@@ -7,29 +7,39 @@
 import Foundation
 
 internal final class PluginManager: Activatable {
-    private var plugins = [ObjectIdentifier : PluginWrapper]()
+    private var plugins = [TypeIdentifier : [ObjectIdentifier : PluginWrapper]]()
     private weak var game: Game?
 
     // MARK: - API
 
-    func add<P: Plugin>(_ pluginProvider: () -> P, for object: P.Object) -> P {
-        let identifier = ObjectIdentifier(P.self)
+    func add<P: Plugin>(_ pluginProvider: () -> P, for object: P.Object, reuseExistingOfSameType: Bool) -> P {
+        let typeIdentifier = TypeIdentifier(type: P.self)
 
-        if let existingPlugin = plugins[identifier] {
-            return existingPlugin.wrapped as! P
+        if reuseExistingOfSameType {
+            if let existingPlugin = plugins[typeIdentifier]?.first?.value {
+                return existingPlugin.wrapped as! P
+            }
         }
 
         let plugin = pluginProvider()
+        let identifier = ObjectIdentifier(plugin)
         let wrapper = PluginWrapper(plugin: plugin, object: object)
-        plugins[identifier] = wrapper
+
+        var pluginsOfType = plugins[typeIdentifier] ?? [:]
+        pluginsOfType[identifier] = wrapper
+        plugins[typeIdentifier] = pluginsOfType
+
         game.map(wrapper.activate)
 
         return plugin
     }
 
     func remove<P: Plugin>(_ plugin: P, from object: P.Object) {
-        let identifier = ObjectIdentifier(P.self)
-        plugins.removeValue(forKey: identifier)?.deactivate()
+        let typeIdentifier = TypeIdentifier(type: P.self)
+        let identifier = ObjectIdentifier(plugin)
+
+        let plugin = plugins[typeIdentifier]?.removeValue(forKey: identifier)
+        plugin?.deactivate()
     }
 
     // MARK: - Activatable
@@ -37,16 +47,35 @@ internal final class PluginManager: Activatable {
     func activate(in game: Game) {
         self.game = game
 
-        for plugin in plugins.values {
-            plugin.activate(in: game)
+        for pluginCollection in plugins.values {
+            for plugin in pluginCollection.values {
+                plugin.activate(in: game)
+            }
         }
     }
 
     func deactivate() {
         game = nil
 
-        for plugin in plugins.values {
-            plugin.deactivate()
+        for pluginCollection in plugins.values {
+            for plugin in pluginCollection.values {
+                plugin.deactivate()
+            }
+        }
+    }
+}
+
+private extension PluginManager {
+    struct TypeIdentifier: Hashable {
+        static func ==(lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
+            return lhs.identifier == rhs.identifier
+        }
+
+        var hashValue: Int { return identifier.hashValue }
+        private let identifier: ObjectIdentifier
+
+        init<T>(type: T.Type) {
+            identifier = ObjectIdentifier(type)
         }
     }
 }

--- a/Sources/Core/Internal/PluginWrapper.swift
+++ b/Sources/Core/Internal/PluginWrapper.swift
@@ -7,6 +7,8 @@
 import Foundation
 
 internal final class PluginWrapper: Activatable {
+    let wrapped: AnyObject
+
     private let activateClosure: (Game) -> Void
     private let deactivateClosure: () -> Void
 
@@ -19,6 +21,7 @@ internal final class PluginWrapper: Activatable {
             }
         }
         deactivateClosure = plugin.deactivate
+        wrapped = plugin
     }
 
     // MARK: - Activatable

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -80,7 +80,7 @@ final class SceneTests: XCTestCase {
         XCTAssertFalse(plugin.isActive)
     }
 
-    func testSamePluginAddedMultipleTimesReturnsSameInstance() {
+    func testReusingSamePluginInstance() {
         let scene = Scene(size: Size(width: 300, height: 300))
 
         let plugin = PluginMock<Scene>()
@@ -90,6 +90,26 @@ final class SceneTests: XCTestCase {
         // an existing plugin instance attached of the same type
         let anotherPlugin = PluginMock<Scene>()
         assertSameInstance(plugin, scene.add(anotherPlugin))
+    }
+
+    func testDisablingPluginReuse() {
+        let scene = Scene(size: Size(width: 300, height: 300))
+
+        let plugin = PluginMock<Scene>()
+        assertSameInstance(plugin, scene.add(plugin))
+
+        let anotherPlugin = PluginMock<Scene>()
+        assertSameInstance(anotherPlugin, scene.add(anotherPlugin, reuseExistingOfSameType: false))
+
+        // Both plugins should now be activated...
+        game.scene = scene
+        XCTAssertTrue(plugin.isActive)
+        XCTAssertTrue(anotherPlugin.isActive)
+
+        // ...and deactivated
+        game.scene = Scene(size: Size(width: 300, height: 300))
+        XCTAssertFalse(plugin.isActive)
+        XCTAssertFalse(anotherPlugin.isActive)
     }
 
     func testReset() {

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -80,6 +80,18 @@ final class SceneTests: XCTestCase {
         XCTAssertFalse(plugin.isActive)
     }
 
+    func testSamePluginAddedMultipleTimesReturnsSameInstance() {
+        let scene = Scene(size: Size(width: 300, height: 300))
+
+        let plugin = PluginMock<Scene>()
+        assertSameInstance(plugin, scene.add(plugin))
+
+        // The 2nd instance shouldn't be used, since the scen already has
+        // an existing plugin instance attached of the same type
+        let anotherPlugin = PluginMock<Scene>()
+        assertSameInstance(plugin, scene.add(anotherPlugin))
+    }
+
     func testReset() {
         let actor = Actor()
         let block = Block(size: .zero, textureCollectionName: "Block")


### PR DESCRIPTION
This change makes all APIs that add plugins to either an actor, camera or scene return either that instance or any existing plugin instance of the same type.

Since all plugin add methods accept an auto closure, no new instance needs to be created in case an existing one already exists. This enables nice extension APIs to be written on top of Imagine Engine.

For example, here's how an audio engine could be integrated into Imagine Engine to provide a way for an actor to play a sound effect:

```swift
extension Actor {
    private var audioPlugin { return add(AudioPlugin()) }

    func playSound(named name: String) {
        audioPlugin.playSound(named: name)
    }
}
```