### PR TITLE
Scene: Add safe area insets API

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -190,6 +190,10 @@
 		527FC80C1F8EBAAB006B1295 /* LabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527FC80B1F8EBAAB006B1295 /* LabelTests.swift */; };
 		528B21511FA382B300CE9967 /* UpdatableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B21501FA382B300CE9967 /* UpdatableCollection.swift */; };
 		528B21521FA382B300CE9967 /* UpdatableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B21501FA382B300CE9967 /* UpdatableCollection.swift */; };
+		52A124CD1FAB9F9700252047 /* GameViewMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A124CC1FAB9F9700252047 /* GameViewMock.swift */; };
+		52A124CE1FAB9F9700252047 /* GameViewMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A124CC1FAB9F9700252047 /* GameViewMock.swift */; };
+		52A124CF1FAB9F9700252047 /* GameViewMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A124CC1FAB9F9700252047 /* GameViewMock.swift */; };
+		52A124D11FABA07500252047 /* EdgeInsets-macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A124D01FABA07500252047 /* EdgeInsets-macOS.swift */; };
 		52C860301F8E374100C6C7A7 /* ActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C8602D1F8E36B600C6C7A7 /* ActorTests.swift */; };
 		52C860361F8E383100C6C7A7 /* ImageMockFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C860341F8E382800C6C7A7 /* ImageMockFactory.swift */; };
 		52C860381F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C860371F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift */; };
@@ -388,6 +392,8 @@
 		527FC8071F8EB83F006B1295 /* CameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraTests.swift; sourceTree = "<group>"; };
 		527FC80B1F8EBAAB006B1295 /* LabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelTests.swift; sourceTree = "<group>"; };
 		528B21501FA382B300CE9967 /* UpdatableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatableCollection.swift; sourceTree = "<group>"; };
+		52A124CC1FAB9F9700252047 /* GameViewMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewMock.swift; sourceTree = "<group>"; };
+		52A124D01FABA07500252047 /* EdgeInsets-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets-macOS.swift"; sourceTree = "<group>"; };
 		52C8602D1F8E36B600C6C7A7 /* ActorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActorTests.swift; sourceTree = "<group>"; };
 		52C860321F8E381600C6C7A7 /* Assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assert.swift; sourceTree = "<group>"; };
 		52C860331F8E381600C6C7A7 /* TimeTraveler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveler.swift; sourceTree = "<group>"; };
@@ -536,6 +542,7 @@
 				522CD6541F8D4512008DB43D /* DisplayLink-iOS+tvOS.swift */,
 				DD21B7421F92EB140034A7CE /* DisplayLink-macOS.swift */,
 				52C860371F8E3A4900C6C7A7 /* DisplayLinkProtocol.swift */,
+				52A124D01FABA07500252047 /* EdgeInsets-macOS.swift */,
 				5253C7DC1FA4D66500D304B5 /* Font+Default.swift */,
 				522CD6571F8D4512008DB43D /* GameView.swift */,
 				522CD6581F8D4512008DB43D /* Grid.swift */,
@@ -596,6 +603,7 @@
 				52C8603A1F8E535100C6C7A7 /* GameMock.swift */,
 				52479F871F8E7CAF00D22A87 /* PluginMock.swift */,
 				52479F811F8E5A6F00D22A87 /* TextureImageLoaderMock.swift */,
+				52A124CC1FAB9F9700252047 /* GameViewMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -934,6 +942,7 @@
 				525688CA1F9CF3E200F87786 /* SceneTests.swift in Sources */,
 				525688CC1F9CF3E200F87786 /* ActionMock.swift in Sources */,
 				525688D31F9CF3E200F87786 /* ImageMockFactory.swift in Sources */,
+				52A124CE1FAB9F9700252047 /* GameViewMock.swift in Sources */,
 				525688D11F9CF3E200F87786 /* Assert.swift in Sources */,
 				525688C71F9CF3E200F87786 /* CameraTests.swift in Sources */,
 				525688C51F9CF3E200F87786 /* ActorTests.swift in Sources */,
@@ -1036,6 +1045,7 @@
 				5253C7F01FA4D97D00D304B5 /* ImageMockFactory.swift in Sources */,
 				5253C7E31FA4D97D00D304B5 /* EventTests.swift in Sources */,
 				5253C7E41FA4D97D00D304B5 /* LabelTests.swift in Sources */,
+				52A124CF1FAB9F9700252047 /* GameViewMock.swift in Sources */,
 				5253C7E91FA4D97D00D304B5 /* ClickGestureRecognizerMock.swift in Sources */,
 				5253C7E51FA4D97D00D304B5 /* SceneTests.swift in Sources */,
 				5253C7EE1FA4D97D00D304B5 /* Assert.swift in Sources */,
@@ -1138,6 +1148,7 @@
 				527FC8061F8EB223006B1295 /* EventTests.swift in Sources */,
 				52479F8E1F8E823E00D22A87 /* ActionMock.swift in Sources */,
 				52479F881F8E7CAF00D22A87 /* PluginMock.swift in Sources */,
+				52A124CD1FAB9F9700252047 /* GameViewMock.swift in Sources */,
 				52C860361F8E383100C6C7A7 /* ImageMockFactory.swift in Sources */,
 				52479F841F8E7B4E00D22A87 /* SceneTests.swift in Sources */,
 				52C8603D1F8E537C00C6C7A7 /* DisplayLinkMock.swift in Sources */,
@@ -1208,6 +1219,7 @@
 				DD21B71C1F92E75A0034A7CE /* Camera.swift in Sources */,
 				DD21B71D1F92E75A0034A7CE /* FadeAction.swift in Sources */,
 				DD21B71E1F92E75A0034A7CE /* Action.swift in Sources */,
+				52A124D11FABA07500252047 /* EdgeInsets-macOS.swift in Sources */,
 				DD21B71F1F92E75A0034A7CE /* Texture.swift in Sources */,
 				DD21B7201F92E75A0034A7CE /* UpdateOutcome.swift in Sources */,
 				523E5D111F9FEFBC0084792C /* SpriteSheet.swift in Sources */,

--- a/Sources/Core/API/Game.swift
+++ b/Sources/Core/API/Game.swift
@@ -29,12 +29,11 @@ open class Game {
 
     /// Initialize an instance with a certain viewport size & an initial scene
     public convenience init(size: Size, scene: Scene) {
-        self.init(size: size, scene: scene, displayLink: DisplayLink())
+        let view = GameView(frame: Rect(origin: .zero, size: size))
+        self.init(view: view, scene: scene, displayLink: DisplayLink())
     }
 
-    internal init(size: Size, scene: Scene, displayLink: DisplayLinkProtocol, dateProvider: @escaping () -> Date = Date.init) {
-        let view = GameView(frame: Rect(origin: .zero, size: size))
-
+    internal init(view: GameView, scene: Scene, displayLink: DisplayLinkProtocol, dateProvider: @escaping () -> Date = Date.init) {
         self.view = view
         self.scene = scene
         self.displayLink = displayLink

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -40,6 +40,9 @@ open class Scene: Activatable {
     public let textureManager = TextureManager()
     /// The current size of the scene
     public var size: Size { didSet { sizeDidChange() } }
+    /// The insets that make up the area that is safe to put content in, to avoid the notch
+    /// & home indicator on iPhone X (can be observed using the safeAreaInsetsChanged event)
+    public internal(set) var safeAreaInsets = EdgeInsets() { didSet { safeAreaInsetsDidChange(from: oldValue) } }
     /// The scene's background color (default is `.clear` = no background color)
     public var backgroundColor = Color.clear { didSet { backgroundColorDidChange() } }
 
@@ -260,6 +263,14 @@ open class Scene: Activatable {
     private func sizeDidChange() {
         layer.bounds.size = size
         camera.sceneSize = size
+    }
+
+    private func safeAreaInsetsDidChange(from oldValue: EdgeInsets) {
+        guard safeAreaInsets != oldValue else {
+            return
+        }
+
+        events.safeAreaInsetsChanged.trigger()
     }
 
     private func backgroundColorDidChange() {

--- a/Sources/Core/API/SceneEventCollection.swift
+++ b/Sources/Core/API/SceneEventCollection.swift
@@ -8,8 +8,10 @@ import Foundation
 
 /// Events that can be used to observe a scene
 public final class SceneEventCollection: EventCollection<Scene> {
-    /// Event that will be triggered when the scene was clicked or tapped
+    /// Event that gets triggered when the scene was clicked or tapped
     public private(set) lazy var clicked = makeClickedEvent()
+    /// Event that gets triggered when its safe area insets changed
+    public private(set) lazy var safeAreaInsetsChanged = Event<Scene, Void>(object: object)
 
     private func makeClickedEvent() -> Event<Scene, Point> {
         object?.add(ClickPlugin())

--- a/Sources/Core/API/Typealiases.swift
+++ b/Sources/Core/API/Typealiases.swift
@@ -15,18 +15,24 @@ public typealias Metric = CGFloat
 
 #if os(macOS)
 import AppKit
+
 public typealias View = NSView
 public typealias Color = NSColor
 public typealias Image = NSImage
 public typealias Screen = NSScreen
 public typealias Font = NSFont
+public typealias EdgeInsets = NSEdgeInsets
+
 internal typealias ClickGestureRecognizer = NSClickGestureRecognizer
 #else
 import UIKit
+
 public typealias View = UIView
 public typealias Color = UIColor
 public typealias Image = UIImage
 public typealias Screen = UIScreen
 public typealias Font = UIFont
+public typealias EdgeInsets = UIEdgeInsets
+
 internal typealias ClickGestureRecognizer = UITapGestureRecognizer
 #endif

--- a/Sources/Core/Internal/DisplayLinkProtocol.swift
+++ b/Sources/Core/Internal/DisplayLinkProtocol.swift
@@ -1,3 +1,9 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
 import Foundation
 
 internal protocol DisplayLinkProtocol: class {

--- a/Sources/Core/Internal/EdgeInsets-macOS.swift
+++ b/Sources/Core/Internal/EdgeInsets-macOS.swift
@@ -1,0 +1,13 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Cocoa
+
+extension EdgeInsets: Equatable {
+    public static func ==(lhs: EdgeInsets, rhs: EdgeInsets) -> Bool {
+        return NSEdgeInsetsEqual(lhs, rhs)
+    }
+}

--- a/Sources/Core/Internal/GameView.swift
+++ b/Sources/Core/Internal/GameView.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal final class GameView: View {
+internal class GameView: View {
     override var frame: Rect { didSet { game?.scene.camera.size = frame.size } }
     weak var game: Game?
 
@@ -20,6 +20,12 @@ internal final class GameView: View {
         super.didMoveToSuperview()
         game?.updateActivationStatus()
     }
+
+    override func safeAreaInsetsDidChange() {
+        if #available(iOS 11, tvOS 11, *) {
+            super.safeAreaInsetsDidChange()
+            game?.scene.safeAreaInsets = safeAreaInsets
+        }
+    }
     #endif
 }
-

--- a/Tests/ImagineEngineTests/Mocks/GameMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/GameMock.swift
@@ -8,6 +8,7 @@ import Foundation
 @testable import ImagineEngine
 
 final class GameMock: Game {
+    let mockedView = GameViewMock()
     let timeTraveler = TimeTraveler()
     let textureImageLoader = TextureImageLoaderMock()
 
@@ -20,7 +21,7 @@ final class GameMock: Game {
         let scene = Scene(size: Size(width: 500, height: 500))
         scene.textureManager.imageLoader = textureImageLoader
 
-        super.init(size: scene.size,
+        super.init(view: mockedView,
                    scene: scene,
                    displayLink: displayLink,
                    dateProvider: timeTraveler.generateDate)

--- a/Tests/ImagineEngineTests/Mocks/GameViewMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/GameViewMock.swift
@@ -1,0 +1,12 @@
+import Foundation
+@testable import ImagineEngine
+
+final class GameViewMock: GameView {
+    var mockedSafeAreaInsets = EdgeInsets()
+
+    #if !os(macOS)
+    override var safeAreaInsets: EdgeInsets {
+        return mockedSafeAreaInsets
+    }
+    #endif
+}

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -157,4 +157,31 @@ final class SceneTests: XCTestCase {
         game.simulateClick(at: Point(x: 200, y: 350))
         XCTAssertEqual(clickedPoint, Point(x: 1050, y: 1550))
     }
+
+    func testSafeAreaInsets() {
+        // Verify default
+        XCTAssertEqual(game.scene.safeAreaInsets, EdgeInsets())
+
+        // This test is only relevant for iOS, since macOS has no concept of safe area insets
+        #if !os(macOS)
+        guard #available(iOS 11, tvOS 11, *) else {
+            return
+        }
+
+        var observationTriggerCount = 0
+
+        game.scene.events.safeAreaInsetsChanged.observe {
+            observationTriggerCount += 1
+        }
+
+        game.mockedView.mockedSafeAreaInsets = EdgeInsets(top: 10, left: 30, bottom: 20, right: 15)
+        game.mockedView.safeAreaInsetsDidChange()
+        XCTAssertEqual(game.scene.safeAreaInsets, EdgeInsets(top: 10, left: 30, bottom: 20, right: 15))
+        XCTAssertEqual(observationTriggerCount, 1)
+
+        // When the same safe area insets get assigned, no observation should be triggered
+        game.mockedView.safeAreaInsetsDidChange()
+        XCTAssertEqual(observationTriggerCount, 1)
+        #endif
+    }
 }


### PR DESCRIPTION
Similar to how UIKit now includes a `safeAreaInsets` API to be able to easily place UI elements away from the notch & home indicator on iPhone X.

Changes required:

- Add `safeAreaInsets` property on `Scene`, note that it’s not only available
on iOS, but on all platforms - preserving the cross platformness of Imagine.

- Add `safeAreaInsetsChanged` event on `SceneEventCollection` that gets triggered
when the safe area insets were changed.

- Make it possible to inject a mocked `GameView` in `Game`, to enable unit testing
of this new feature.

- Make a cross-platform type alias of `NS/UIEdgeInsets = EdgeInsets`.

Here's the new API in use in the start screen of Revazendo, to position the version & copyright labels 😄 

![simulator screen shot - iphone x - 2017-11-02 at 19 33 35](https://user-images.githubusercontent.com/2466701/32345580-e82da428-c00a-11e7-9ab1-6ae4a744bc0d.png)
