### PR TITLE
Actor/Animation: Add convenience initializer that takes a texture name

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -281,6 +281,14 @@ public final class Actor: InstanceHashable, ActionPerformer, Pluggable, Activata
 }
 
 public extension Actor {
+    /// Initialize an actor that renders a single texture with a given name
+    convenience init(textureNamed textureName: String, scale: Int? = nil, format: TextureFormat? = nil) {
+        self.init()
+        defer {
+            animation = Animation(textureNamed: textureName, scale: scale, format: format)
+        }
+    }
+
     /// Initialize an actor that renders a single image as its animation
     convenience init(image: Image) {
         self.init()

--- a/Sources/Core/API/Animation.swift
+++ b/Sources/Core/API/Animation.swift
@@ -58,8 +58,9 @@ public extension Animation {
     }
 
     /// Initialize an instance with a single texture with a certain image name
-    init(textureNamed textureName: String, format: TextureFormat? = nil) {
+    init(textureNamed textureName: String, scale: Int? = nil, format: TextureFormat? = nil) {
         content = .texture(Texture(name: textureName, format: format))
+        textureScale = scale
         updateIdentifier()
     }
 

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -116,12 +116,15 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(game.textureImageLoader.imageNames, ["sheet.png", "sheet2.png"])
     }
 
+    func testInitializingWithTextureName() {
+        let actor = Actor(textureNamed: "SomeTexture", scale: 1)
+        game.scene.add(actor)
+        XCTAssertEqual(game.textureImageLoader.imageNames, ["SomeTexture.png"])
+    }
+
     func testTextureNamePrefix() {
         actor.textureNamePrefix = "Prefix"
-
-        var animation = Animation(textureNamed: "Texture")
-        animation.textureScale = 1
-        actor.animation = animation
+        actor.animation = Animation(textureNamed: "Texture", scale: 1)
 
         game.update()
         XCTAssertEqual(game.textureImageLoader.imageNames, ["PrefixTexture.png"])


### PR DESCRIPTION
This change makes it possible to initialize an actor with just a texture name, which is very common for single-image actors. It also adds a `scale` parameter to the `Animation` initializer that takes a texture name.