### PR TITLE
TextureManager: Add support for assigning a scene-wide name prefix

### DIFF
--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -15,6 +15,9 @@ public final class TextureManager {
     public var defaultScale: Int = Int(Screen.mainScreenScale)
     /// The default format when loading textures (default = PNG)
     public var defaultFormat: TextureFormat = .png
+    /// Any name prefix to apply to all loaded textures (default = nil)
+    /// If an actor has a name prefix of its own, this prefix will be applied first
+    public var namePrefix: String?
 
     internal private(set) var cache = [String : LoadedTexture]()
 
@@ -34,10 +37,14 @@ public final class TextureManager {
 
     // MARK: - Internal
 
-    internal func load(_ texture: Texture, namePrefix: String?, scale: Int?) -> LoadedTexture? {
+    internal func load(_ texture: Texture, namePrefix additionalNamePrefix: String?, scale: Int?) -> LoadedTexture? {
         let scale = scale ?? defaultScale
         let format = texture.format ?? defaultFormat
         var name = texture.name
+
+        if let prefix = additionalNamePrefix {
+            name = "\(prefix)\(name)"
+        }
 
         if let prefix = namePrefix {
             name = "\(prefix)\(name)"

--- a/Tests/ImagineEngineTests/TextureManagerTests.swift
+++ b/Tests/ImagineEngineTests/TextureManagerTests.swift
@@ -12,12 +12,16 @@ class TextureManagerTests: XCTestCase {
     private var manager: TextureManager!
     private var imageLoader: TextureImageLoaderMock!
 
+    // MARK: - XCTestCase
+
     override func setUp() {
         super.setUp()
         manager = TextureManager()
         imageLoader = TextureImageLoaderMock()
         manager.imageLoader = imageLoader
     }
+
+    // MARK: - Tests
 
     func testFallsBackToLowerScaleTextures() {
         _ = manager.load(Texture(name: "texture"), namePrefix: nil, scale: 3)
@@ -52,6 +56,20 @@ class TextureManagerTests: XCTestCase {
         assertSameInstance(loadedPNGTexture?.image, pngImage)
         assertSameInstance(loadedJPGTexture?.image, jpgImage)
     }
+
+    func testApplyingTextureNamePrefix() {
+        let texture = Texture(name: "Texture")
+        manager.namePrefix = "Prefix"
+
+        _ = manager.load(texture, namePrefix: nil, scale: 1)
+        XCTAssertEqual(imageLoader.imageNames, ["PrefixTexture.png"])
+
+        // When an additional name prefix is passed in, both prefixes should be applied in sequence
+        _ = manager.load(texture, namePrefix: "Second", scale: 1)
+        XCTAssertEqual(imageLoader.imageNames, ["PrefixTexture.png", "PrefixSecondTexture.png"])
+    }
+
+    // MARK: - Utilities
 
     private func makeImage() -> CGImage {
         return ImageMockFactory.makeCGImage(withSize: Size(width: 1, height: 1))


### PR DESCRIPTION
This change adds a `namePrefix` property on `TextureManager`, that can be used to assign a prefix to all textures loaded by that manager. This is super useful when all graphics for a game are contained in a single folder, and lets you skip referring to that folder every time you reference a texture.