### PR TITLE
Actor: Adapt rect according to scale

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -209,7 +209,7 @@ public final class Actor: InstanceHashable, ActionPerformer, Pluggable, Activata
         }
 
         layer.scale = scale
-        rectDidChange()
+        updateRect()
     }
 
     private func velocityDidChange(from oldValue: Vector) {
@@ -259,8 +259,10 @@ public final class Actor: InstanceHashable, ActionPerformer, Pluggable, Activata
 
     private func updateRect() {
         var newRect = Rect(origin: position, size: size)
-        newRect.origin.x -= size.width / 2
-        newRect.origin.y -= size.height / 2
+        newRect.size.width *= scale
+        newRect.size.height *= scale
+        newRect.origin.x -= newRect.width / 2
+        newRect.origin.y -= newRect.height / 2
         rect = newRect
     }
 
@@ -313,13 +315,13 @@ public extension Actor {
 
 internal extension Actor {
     var rectForCollisionDetection: Rect {
-        let scaledSize = hitboxSize ?? Size(width: rect.width * scale, height: rect.height * scale)
-        return Rect(
-            origin: Point(
-                x: position.x - scaledSize.width / 2,
-                y: position.y - scaledSize.height / 2
-            ),
-            size: scaledSize
-        )
+        if let hitboxSize = hitboxSize {
+            var rect = Rect(origin: position, size: hitboxSize)
+            rect.origin.x -= hitboxSize.width / 2
+            rect.origin.y -= hitboxSize.height / 2
+            return rect
+        }
+
+        return rect
     }
 }

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -31,6 +31,10 @@ final class ActorTests: XCTestCase {
 
         actor.size = Size(width: 100, height: 300)
         XCTAssertEqual(actor.rect, Rect(x: 100, y: 50, width: 100, height: 300))
+
+        // The actor's rect should be adapted if its scale is changed
+        actor.scale = 3
+        XCTAssertEqual(actor.rect, Rect(x: 0, y: -250, width: 300, height: 900))
     }
 
     func testAnimationAutoResizingActor() {


### PR DESCRIPTION
This change makes an actor’s rect adapt according to its scale. Otherwise an actor’s `rect` property doesn’t match the actual pixels its being rendered on.