### PR TITLE
Actor: Remove use of defer to trigger property observers

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -286,25 +286,22 @@ public extension Actor {
     /// Initialize an actor that renders a single texture with a given name
     convenience init(textureNamed textureName: String, scale: Int? = nil, format: TextureFormat? = nil) {
         self.init()
-        defer {
-            animation = Animation(textureNamed: textureName, scale: scale, format: format)
-        }
+        animation = Animation(textureNamed: textureName, scale: scale, format: format)
+        animationDidChange(from: nil)
     }
 
     /// Initialize an actor that renders a single image as its animation
     convenience init(image: Image) {
         self.init()
-        defer {
-            animation = Animation(image: image)
-        }
+        animation = Animation(image: image)
+        animationDidChange(from: nil)
     }
 
     /// Initialize an actor with a given size
     convenience init(size: Size) {
         self.init()
-        defer {
-            self.size = size
-        }
+        self.size = size
+        sizeDidChange(from: .zero)
     }
 
     /// Makes the actor start playing an animation as an action


### PR DESCRIPTION
This change removes the use of `defer` to trigger a property’s `didSet` observation. While this currently works, it has been confirmed to be because of a compiler bug that will will be fixed soon.

Instead of relying on defer, the methods dealing with changes in values are now explicitly called during init instead.