### PR TITLE
ActionPerformer: Add convenience API to repeat an action

### DIFF
--- a/Sources/Core/API/RepeatAction.swift
+++ b/Sources/Core/API/RepeatAction.swift
@@ -26,7 +26,7 @@ public final class RepeatAction<Object: AnyObject>: Action<Object> {
 
 public extension ActionPerformer {
     /// Repeat an action until its cancelled using the returned token
-    func `repeat`(_ action: Action<Self>) -> ActionToken {
+    @discardableResult func `repeat`(_ action: Action<Self>) -> ActionToken {
         return perform(RepeatAction(action: action))
     }
 }

--- a/Sources/Core/API/RepeatAction.swift
+++ b/Sources/Core/API/RepeatAction.swift
@@ -23,3 +23,10 @@ public final class RepeatAction<Object: AnyObject>: Action<Object> {
         return .continueAfter(0)
     }
 }
+
+public extension ActionPerformer {
+    /// Repeat an action until its cancelled using the returned token
+    func `repeat`(_ action: Action<Self>) -> ActionToken {
+        return perform(RepeatAction(action: action))
+    }
+}

--- a/Tests/ImagineEngineTests/ActionTests.swift
+++ b/Tests/ImagineEngineTests/ActionTests.swift
@@ -164,4 +164,37 @@ final class ActionTests: XCTestCase {
         XCTAssertNil(actionB.context)
         XCTAssertNil(actionC.context)
     }
+
+    func testRepeatingAction() {
+        let moveVector = Vector(dx: 100, dy: 50)
+        let moveAction = MoveAction<Actor>(vector: moveVector, duration: 2)
+
+        let actor = Actor()
+        let token = actor.repeat(moveAction)
+        game.scene.add(actor)
+        game.update()
+
+        game.timeTraveler.travel(by: 2)
+        game.update()
+        XCTAssertEqual(actor.position, Point(x: 100, y: 50))
+
+        // Actor should keep moving, since the action is repeated
+        // (after an intermediate update to reset state)
+        game.update()
+        game.timeTraveler.travel(by: 1)
+        game.update()
+        XCTAssertEqual(actor.position, Point(x: 150, y: 75))
+
+        // After the token is cancelled, the repeated action should be cancelled
+        token.cancel()
+        game.timeTraveler.travel(by: 1)
+        game.update()
+        XCTAssertEqual(actor.position, Point(x: 150, y: 75))
+
+        // The action shoudn't be repeated anymore either
+        game.update()
+        game.timeTraveler.travel(by: 1)
+        game.update()
+        XCTAssertEqual(actor.position, Point(x: 150, y: 75))
+    }
 }


### PR DESCRIPTION
This change adds a simple convenience API on all action performs to enable an action to be repeated until its cancelled.