### PR TITLE
Plugins: Add API for removing all plugins of a type

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -100,6 +100,10 @@ public final class Actor: InstanceHashable, ActionPerformer, Pluggable, Activata
         pluginManager.remove(plugin, from: self)
     }
 
+    public func removePlugins<P: Plugin>(ofType type: P.Type) where P.Object == Actor {
+        pluginManager.removePlugins(ofType: type, from: self)
+    }
+
     // MARK: - Activatable
 
     internal func activate(in game: Game) {

--- a/Sources/Core/API/Camera.swift
+++ b/Sources/Core/API/Camera.swift
@@ -54,6 +54,10 @@ public final class Camera: ActionPerformer, Pluggable, Movable, Activatable {
         pluginManager.remove(plugin, from: self)
     }
 
+    public func removePlugins<P: Plugin>(ofType type: P.Type) where P.Object == Camera {
+        pluginManager.removePlugins(ofType: type, from: self)
+    }
+
     // MARK: - Activatable
 
     internal func activate(in game: Game) {

--- a/Sources/Core/API/Pluggable.swift
+++ b/Sources/Core/API/Pluggable.swift
@@ -23,6 +23,9 @@ public protocol Pluggable: class {
 
     /// Remove a plugin from this object
     func remove<P: Plugin>(_ plugin: P) where P.Object == PluginTarget
+
+    /// Remove all plugins of a certain type from this object
+    func removePlugins<P: Plugin>(ofType type: P.Type) where P.Object == PluginTarget
 }
 
 public extension Pluggable {

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -188,6 +188,10 @@ open class Scene: Pluggable, Activatable {
         pluginManager.remove(plugin, from: self)
     }
 
+    public func removePlugins<P: Plugin>(ofType type: P.Type) where P.Object == Scene {
+        pluginManager.removePlugins(ofType: type, from: self)
+    }
+
     // MARK: - Activatable
     
     internal func activate(in game: Game) {

--- a/Sources/Core/Internal/PluginManager.swift
+++ b/Sources/Core/Internal/PluginManager.swift
@@ -42,6 +42,18 @@ internal final class PluginManager: Activatable {
         plugin?.deactivate()
     }
 
+    func removePlugins<P: Plugin>(ofType: P.Type, from object: P.Object) {
+        let typeIdentifier = TypeIdentifier(type: P.self)
+
+        guard let pluginsOfType = plugins.removeValue(forKey: typeIdentifier) else {
+            return
+        }
+
+        for plugin in pluginsOfType.values {
+            plugin.deactivate()
+        }
+    }
+
     // MARK: - Activatable
 
     func activate(in game: Game) {

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -92,6 +92,28 @@ final class SceneTests: XCTestCase {
         assertSameInstance(plugin, scene.add(anotherPlugin))
     }
 
+    func testRemovingAllPluginsOfType() {
+        var pluginA: PluginMock! = PluginMock<Scene>()
+        var pluginB: PluginMock! = PluginMock<Scene>()
+
+        game.scene.add(pluginA)
+        game.scene.add(pluginB, reuseExistingOfSameType: false)
+        XCTAssertTrue(pluginA.isActive)
+        XCTAssertTrue(pluginB.isActive)
+
+        game.scene.removePlugins(ofType: PluginMock.self)
+        XCTAssertFalse(pluginA.isActive)
+        XCTAssertFalse(pluginB.isActive)
+
+        // Make sure the scene is not still retaining the plugins after removing them
+        weak var weakPluginA = pluginA
+        weak var weakPluginB = pluginB
+        pluginA = nil
+        pluginB = nil
+        XCTAssertNil(weakPluginA)
+        XCTAssertNil(weakPluginB)
+    }
+
     func testDisablingPluginReuse() {
         let scene = Scene(size: Size(width: 300, height: 300))
 


### PR DESCRIPTION
This change adds an API on `Pluggable` for removing all plugins of a certain type. This is very useful in situations where you don’t want to keep a reference to a certain plugin in order to be able to remove it.