### PR TITLE
Scene: Deactivate objects directly when resetting

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -80,17 +80,9 @@ open class Scene: Pluggable, Activatable {
     /// reset it to its initial state. Once the reset has been completed,
     /// the `setup()` and `activate()` methods will be called.
     public func reset() {
-        for actor in actors {
-            remove(actor)
-        }
-
-        for block in blocks {
-            remove(block)
-        }
-
-        for label in labels {
-            remove(label)
-        }
+        actors.forEach(deactivate)
+        blocks.forEach(deactivate)
+        labels.forEach(deactivate)
 
         camera = Camera(layer: layer, sceneSize: size)
         camera.position = Point(x: size.width / 2, y: size.height / 2)

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -152,6 +152,11 @@ final class SceneTests: XCTestCase {
         XCTAssertTrue(game.scene.blocks.isEmpty)
         XCTAssertTrue(game.scene.labels.isEmpty)
 
+        // All objects should have their scene reference removed
+        XCTAssertNil(actor.scene)
+        XCTAssertNil(block.scene)
+        XCTAssertNil(label.scene)
+
         // Plugins should not be removed as part of a reset
         XCTAssertTrue(plugin.isActive)
 


### PR DESCRIPTION
No need to go through the Grid, as it’s about to be reset as well. This change also adds some more verification to the test for the reset operation.