### PR TITLE
Scene: Toggle plugin activation when reset

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -84,16 +84,18 @@ open class Scene: Pluggable, Activatable {
         actors.forEach(deactivate)
         blocks.forEach(deactivate)
         labels.forEach(deactivate)
+        pluginManager.deactivate()
 
         camera = Camera(layer: layer, sceneSize: size)
         camera.position = Point(x: size.width / 2, y: size.height / 2)
 
         events = SceneEventCollection(object: self)
         grid = Grid()
-
         timeline = Timeline()
+
         game.map(timeline.activate)
         game.map(camera.activate)
+        game.map(pluginManager.activate)
 
         setup()
         activate()

--- a/Tests/ImagineEngineTests/Mocks/PluginMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/PluginMock.swift
@@ -11,14 +11,18 @@ final class PluginMock<Object: AnyObject>: Plugin {
     private(set) weak var object: Object?
     private(set) weak var game: Game?
     private(set) var isActive = false
+    private(set) var activationCount = 0
+    private(set) var deactivationCount = 0
 
     func activate(for object: Object, in game: Game) {
         self.object = object
         self.game = game
         isActive = true
+        activationCount += 1
     }
 
     func deactivate() {
         isActive = false
+        deactivationCount += 1
     }
 }

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -157,7 +157,10 @@ final class SceneTests: XCTestCase {
         XCTAssertNil(block.scene)
         XCTAssertNil(label.scene)
 
-        // Plugins should not be removed as part of a reset
+        // Plugins should not be removed as part of a reset, but they
+        // should have been deactivated and then activated again
+        XCTAssertEqual(plugin.deactivationCount, 1)
+        XCTAssertEqual(plugin.activationCount, 2)
         XCTAssertTrue(plugin.isActive)
 
         // Camera should be back at the starting point


### PR DESCRIPTION
When resetting a scene, we don’t want to remove its plugins, but we do want them to be deactivated and then re-activated. This because some plugins observe events on its scene, and those events get removed as part of a reset.