### PR TITLE
Scene: Render initial background color

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -61,6 +61,7 @@ open class Scene: Pluggable, Activatable {
 
         layer.isOpaque = true
         sizeDidChange()
+        backgroundColorDidChange()
         setup()
     }
 


### PR DESCRIPTION
Now that we have a black color as the default, we need to call `backgroundColorDidChange()` in init in order to get it to be rendered by the layer.