### PR TITLE
Timeline: Support passing a weak-referenced object to closures

### DIFF
--- a/Sources/Core/Internal/ClosureUpdatable.swift
+++ b/Sources/Core/Internal/ClosureUpdatable.swift
@@ -7,21 +7,20 @@
 import Foundation
 
 internal final class ClosureUpdatable: Updatable {
-    private let closure: () -> Void
-    private let repeatInterval: TimeInterval?
+    private let closure: () -> UpdateOutcome
 
-    init(closure: @escaping () -> Void, repeatInterval: TimeInterval?) {
+    init(closure: @escaping () -> Void) {
+        self.closure = {
+            closure()
+            return .finished
+        }
+    }
+
+    init(closure: @escaping () -> UpdateOutcome) {
         self.closure = closure
-        self.repeatInterval = repeatInterval
     }
 
     func update(currentTime: TimeInterval) -> UpdateOutcome {
-        closure()
-
-        guard let repeatInterval = repeatInterval else {
-            return .finished
-        }
-
-        return .continueAfter(repeatInterval)
+        return closure()
     }
 }

--- a/Tests/ImagineEngineTests/TimelineTests.swift
+++ b/Tests/ImagineEngineTests/TimelineTests.swift
@@ -37,6 +37,23 @@ final class TimelineTests: XCTestCase {
         XCTAssertEqual(runCount, 1)
     }
 
+    func testRunningClosureAfterIntervalWithObject() {
+        var actor = Actor()
+        weak var passedActor: Actor?
+
+        game.scene.timeline.after(interval: 2, using: actor) { actor in
+            passedActor = actor
+        }
+
+        game.timeTraveler.travel(by: 2)
+        game.update()
+        assertSameInstance(actor, passedActor)
+
+        // Make sure the object is not retained by the timeline
+        actor = Actor()
+        XCTAssertNil(passedActor)
+    }
+
     func testRepeatingClosureUntilCancelled() {
         var runCount = 0
 
@@ -64,5 +81,22 @@ final class TimelineTests: XCTestCase {
         game.timeTraveler.travel(by: 3)
         game.update()
         XCTAssertEqual(runCount, 3)
+    }
+
+    func testRepeatingClosureWithObject() {
+        var actor = Actor()
+        weak var passedActor: Actor?
+
+        game.scene.timeline.repeat(withInterval: 2, using: actor) { actor in
+            passedActor = actor
+        }
+
+        game.timeTraveler.travel(by: 2)
+        game.update()
+        assertSameInstance(actor, passedActor)
+
+        // Make sure the object is not retained by the timeline
+        actor = Actor()
+        XCTAssertNil(passedActor)
     }
 }


### PR DESCRIPTION
This change makes it possible to pass any object into a timeline closure to have it automatically weak-reference it. If the object is deallocated, then the timeline will discard the event and associated closure.

**This enables you to replace this:**

```swift
timeline.repeat(withInterval: 5) { [weak self] in
    self?.doSomething()
}
```

**with this:**

```swift
timeline.repeat(withInterval: 5, using: self) { scene in
    scene.doSomething()
}
```

It also has the added benefit of automatically cancelling any timeline event if the associated object is deallocated.