### PR TITLE
ActionToken: Support passing a weak-referenced object to ‘then’ closure

### DIFF
--- a/Sources/Core/API/ActionToken.swift
+++ b/Sources/Core/API/ActionToken.swift
@@ -95,6 +95,16 @@ public final class ActionToken: CancellationToken {
     }
 }
 
+public extension ActionToken {
+    /// Run a closure after the action that this token is for has finished, passing in a given object
+    /// to the closure (the object won't be retained and the closure won't be run if it's deallocated)
+    @discardableResult func then<T: AnyObject>(using object: T, run closure: @escaping (T) -> Void) -> ActionToken {
+        return then { [weak object] in
+            object.map(closure)
+        }
+    }
+}
+
 internal extension ActionToken {
     enum ChainItem {
         case token(ActionToken)


### PR DESCRIPTION
Similar to the recent change to enable an object to be passed into a timeline closure, with this change it’s now possible to pass any object into an action’s completion handler and have it automatically be weak referenced - eliminating the need to do `[weak self] in`.