### PR TITLE
Grid: taking an actor's scale into account when evaluating actor scene constraint

### DIFF
--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -86,10 +86,10 @@ internal final class Grid {
     func actorRectDidChange(_ actor: Actor, in scene: Scene) {
         if actor.constraints.contains(.scene) {
             var adjustedPosition = actor.position
-            adjustedPosition.x = min(scene.size.width - actor.size.width / 2,
-                                     max(actor.size.width / 2, actor.position.x))
-            adjustedPosition.y = min(scene.size.height - actor.size.height / 2,
-                                     max(actor.size.height / 2, actor.position.y))
+            adjustedPosition.x = min(scene.size.width - actor.rect.width / 2,
+                                     max(actor.rect.width / 2, actor.position.x))
+            adjustedPosition.y = min(scene.size.height - actor.rect.height / 2,
+                                     max(actor.rect.height / 2, actor.position.y))
 
             if adjustedPosition != actor.position {
                 actor.position = adjustedPosition

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -175,6 +175,15 @@ final class ActorTests: XCTestCase {
 
         actor.position.y = 600
         XCTAssertEqual(actor.position.y, 450)
+        
+        // Set actor scale
+        actor.scale = 0.5
+
+        actor.position.x = 500
+        XCTAssertEqual(actor.position.x, 475)
+        
+        actor.position.y = 600
+        XCTAssertEqual(actor.position.x, 475)
 
         // Removing the constraint should free the actor to move outside of the scene
         actor.constraints = []

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -183,7 +183,7 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(actor.position.x, 475)
         
         actor.position.y = 600
-        XCTAssertEqual(actor.position.x, 475)
+        XCTAssertEqual(actor.position.y, 475)
 
         // Removing the constraint should free the actor to move outside of the scene
         actor.constraints = []


### PR DESCRIPTION
Now we use the actor's ```rect```, instead of actor's ```size```, because the ```rect``` is already adjusted for its scale. 