### PR TITLE
CI: Add Danger

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,12 @@
+# Show SwiftLint warnings inline in the diff
+swiftlint.lint_files inline_mode: true
+
+# Warning to discourage big PRs
+if git.lines_of_code > 500
+    warn "Your PR has over 500 lines of code 😱 Try to break it up into separate PRs if possible 👍"
+end
+
+# Warning to encourage a PR description
+if github.pr_body.length == 0
+    warn "Please add a decription to your PR to make it easier to review 👌"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'danger'
+gem 'danger-swiftlint'

--- a/buddybuild_finally.sh
+++ b/buddybuild_finally.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-chruby 2.3.1
-bundle install
-bundle exec danger --fail-on-errors=true

--- a/buddybuild_finally.sh
+++ b/buddybuild_finally.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+chruby 2.3.1
+bundle install
+bundle exec danger --fail-on-errors=true

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -7,4 +7,4 @@ xcodebuild clean test -project ImagineEngine.xcodeproj -scheme ImagineEngine-tvO
 # Run danger
 chruby 2.3.1
 bundle install
-bundle exec danger --fail-on-errors=true
+bundle exec danger

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
+# Run tests on macOS + tvOS
 xcodebuild clean test -project ImagineEngine.xcodeproj -scheme ImagineEngine-macOS -destination "platform=OS X" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
 xcodebuild clean test -project ImagineEngine.xcodeproj -scheme ImagineEngine-tvOS -destination "platform=tvOS Simulator,name=Apple TV 1080p" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+
+# Run danger
+bundle install
+bundle exec danger --fail-on-errors=true

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -5,5 +5,6 @@ xcodebuild clean test -project ImagineEngine.xcodeproj -scheme ImagineEngine-mac
 xcodebuild clean test -project ImagineEngine.xcodeproj -scheme ImagineEngine-tvOS -destination "platform=tvOS Simulator,name=Apple TV 1080p" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
 
 # Run danger
+chruby 2.3.1
 bundle install
 bundle exec danger --fail-on-errors=true


### PR DESCRIPTION
This change adds Danger to the CI process, to show linting warnings inline and whether a PR is too big or lacks a description.

For now this uses the standard Ruby version of Danger, but we should totally use Danger-Swift & Marathon in the future.