### PR TITLE
Adds errorMode to TextureManager for Debug Mode.

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -1640,6 +1640,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ImagineEngine.ImagineEngine-iOS";
 				PRODUCT_NAME = ImagineEngine;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
@@ -1678,6 +1679,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ImagineEngine.ImagineEngine-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
@@ -1719,6 +1721,7 @@
 				PRODUCT_NAME = ImagineEngine;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;

--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -234,6 +234,9 @@
 		C86A78BF1FA1B61A0099632B /* TextureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */; };
 		C8D2FCE51FA493940077B560 /* BundleTextureImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */; };
 		C8D2FCE61FA493940077B560 /* BundleTextureImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */; };
+		CDC7F0041FC419F300782197 /* TextureErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */; };
+		CDC7F0051FC419F300782197 /* TextureErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */; };
+		CDC7F0061FC419F300782197 /* TextureErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */; };
 		DD21B6F21F92E75A0034A7CE /* View+MakeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6641F8D4512008DB43D /* View+MakeLayer.swift */; };
 		DD21B6F31F92E75A0034A7CE /* PluginWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD65D1F8D4512008DB43D /* PluginWrapper.swift */; };
 		DD21B6F41F92E75A0034A7CE /* Scalable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6471F8D4512008DB43D /* Scalable.swift */; };
@@ -429,6 +432,7 @@
 		C800CE3D1FA790A9008EE08D /* sample.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = sample.jpg; sourceTree = "<group>"; };
 		C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureManagerTests.swift; sourceTree = "<group>"; };
 		C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTextureImageLoader.swift; sourceTree = "<group>"; };
+		CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureErrorHandler.swift; sourceTree = "<group>"; };
 		DD21B7361F92E75A0034A7CE /* ImagineEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ImagineEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD21B7381F92E81C0034A7CE /* Image-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image-macOS.swift"; sourceTree = "<group>"; };
 		DD21B73B1F92E8B90034A7CE /* Screen-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Screen-macOS.swift"; sourceTree = "<group>"; };
@@ -580,6 +584,7 @@
 				522CD6621F8D4512008DB43D /* UpdatableWrapper.swift */,
 				522CD6631F8D4512008DB43D /* UpdateOutcome.swift */,
 				522CD6641F8D4512008DB43D /* View+MakeLayer.swift */,
+				CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -1249,6 +1254,7 @@
 				DD21B6F41F92E75A0034A7CE /* Scalable.swift in Sources */,
 				DD21B6F51F92E75A0034A7CE /* Plugin.swift in Sources */,
 				520484A21FA357070011D372 /* ClickGestureRecognizer-macOS.swift in Sources */,
+				CDC7F0051FC419F300782197 /* TextureErrorHandler.swift in Sources */,
 				DD21B6F61F92E75A0034A7CE /* ActorEventCollection.swift in Sources */,
 				DD21B6F71F92E75A0034A7CE /* Movable.swift in Sources */,
 				DD21B7411F92EA610034A7CE /* ClickPlugin.swift in Sources */,

--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -1079,6 +1079,7 @@
 				5253C7B91FA4D57200D304B5 /* AnimationAction.swift in Sources */,
 				5253C7D11FA4D57200D304B5 /* RotateAction.swift in Sources */,
 				5253C7A91FA4D56C00D304B5 /* PluginManager.swift in Sources */,
+				CDC7F0061FC419F300782197 /* TextureErrorHandler.swift in Sources */,
 				5253C7DA1FA4D57200D304B5 /* Timeline.swift in Sources */,
 				5253C7A41FA4D56C00D304B5 /* GameView.swift in Sources */,
 				5253C7CC1FA4D57200D304B5 /* MoveAction.swift in Sources */,

--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -237,6 +237,9 @@
 		CDC7F0041FC419F300782197 /* TextureErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */; };
 		CDC7F0051FC419F300782197 /* TextureErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */; };
 		CDC7F0061FC419F300782197 /* TextureErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */; };
+		CDC7F00B1FC42E6500782197 /* TextureErrorHandlerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0071FC42D4800782197 /* TextureErrorHandlerMock.swift */; };
+		CDC7F00C1FC42E6600782197 /* TextureErrorHandlerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0071FC42D4800782197 /* TextureErrorHandlerMock.swift */; };
+		CDC7F00D1FC42E6700782197 /* TextureErrorHandlerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC7F0071FC42D4800782197 /* TextureErrorHandlerMock.swift */; };
 		DD21B6F21F92E75A0034A7CE /* View+MakeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6641F8D4512008DB43D /* View+MakeLayer.swift */; };
 		DD21B6F31F92E75A0034A7CE /* PluginWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD65D1F8D4512008DB43D /* PluginWrapper.swift */; };
 		DD21B6F41F92E75A0034A7CE /* Scalable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6471F8D4512008DB43D /* Scalable.swift */; };
@@ -433,6 +436,7 @@
 		C86A78BD1FA1B61A0099632B /* TextureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureManagerTests.swift; sourceTree = "<group>"; };
 		C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTextureImageLoader.swift; sourceTree = "<group>"; };
 		CDC7F0031FC419F300782197 /* TextureErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureErrorHandler.swift; sourceTree = "<group>"; };
+		CDC7F0071FC42D4800782197 /* TextureErrorHandlerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureErrorHandlerMock.swift; sourceTree = "<group>"; };
 		DD21B7361F92E75A0034A7CE /* ImagineEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ImagineEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD21B7381F92E81C0034A7CE /* Image-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image-macOS.swift"; sourceTree = "<group>"; };
 		DD21B73B1F92E8B90034A7CE /* Screen-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Screen-macOS.swift"; sourceTree = "<group>"; };
@@ -628,6 +632,7 @@
 				52479F871F8E7CAF00D22A87 /* PluginMock.swift */,
 				52479F811F8E5A6F00D22A87 /* TextureImageLoaderMock.swift */,
 				52A124CC1FAB9F9700252047 /* GameViewMock.swift */,
+				CDC7F0071FC42D4800782197 /* TextureErrorHandlerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1010,6 +1015,7 @@
 				525688D01F9CF3E200F87786 /* TextureImageLoaderMock.swift in Sources */,
 				525688C81F9CF3E200F87786 /* EventTests.swift in Sources */,
 				525688CE1F9CF3E200F87786 /* GameMock.swift in Sources */,
+				CDC7F00C1FC42E6600782197 /* TextureErrorHandlerMock.swift in Sources */,
 				C86A78BF1FA1B61A0099632B /* TextureManagerTests.swift in Sources */,
 				525688C91F9CF3E200F87786 /* LabelTests.swift in Sources */,
 				525688CA1F9CF3E200F87786 /* SceneTests.swift in Sources */,
@@ -1117,6 +1123,7 @@
 				5253C7ED1FA4D97D00D304B5 /* TextureImageLoaderMock.swift in Sources */,
 				5253C7EF1FA4D97D00D304B5 /* TimeTraveler.swift in Sources */,
 				5253C7E81FA4D97D00D304B5 /* ActionMock.swift in Sources */,
+				CDC7F00D1FC42E6700782197 /* TextureErrorHandlerMock.swift in Sources */,
 				5253C7E71FA4D97D00D304B5 /* TimelineTests.swift in Sources */,
 				5253C7EA1FA4D97D00D304B5 /* DisplayLinkMock.swift in Sources */,
 				5253C7F01FA4D97D00D304B5 /* ImageMockFactory.swift in Sources */,
@@ -1180,6 +1187,7 @@
 				522CD6901F8D4521008DB43D /* ActionWrapper.swift in Sources */,
 				522CD6771F8D451D008DB43D /* EventCollection.swift in Sources */,
 				522CD6711F8D451D008DB43D /* BlockTextureCollection.swift in Sources */,
+				CDC7F0041FC419F300782197 /* TextureErrorHandler.swift in Sources */,
 				522CD66F1F8D451D008DB43D /* AnimationAction.swift in Sources */,
 				522CD6891F8D451D008DB43D /* ScaleAction.swift in Sources */,
 				522CD66B1F8D451D008DB43D /* ActionToken.swift in Sources */,
@@ -1224,6 +1232,7 @@
 				527FC8081F8EB83F006B1295 /* CameraTests.swift in Sources */,
 				52C8603B1F8E535100C6C7A7 /* GameMock.swift in Sources */,
 				52479F861F8E7BFD00D22A87 /* TimeTraveler.swift in Sources */,
+				CDC7F00B1FC42E6500782197 /* TextureErrorHandlerMock.swift in Sources */,
 				C86A78BE1FA1B61A0099632B /* TextureManagerTests.swift in Sources */,
 				52479F8A1F8E804F00D22A87 /* TimelineTests.swift in Sources */,
 				527FC8061F8EB223006B1295 /* EventTests.swift in Sources */,

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -7,7 +7,6 @@
 import Foundation
 import CoreGraphics
 
-
 ///    This Enum decides how to handle Errors while loading images for a texture.
 ///    Setting this only works in DEBUG mode
 public enum ErrorMode {

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -26,7 +26,7 @@ public enum ErrorMode {
 public final class TextureManager {
     /// The image loader that should be used (default = load from bundle)
     public var imageLoader: TextureImageLoader
-    /// The Error Handler that should be used (default implementation is provided in this class: DefaultTextureErrorHandler)
+    /// The Error Handler that should be used (default = DefaultTextureErrorHandler)
     public var errorHandler: TextureErrorHandler
     /// The default scale when loading textures (default = the main screen's scale)
     public var defaultScale: Int = Int(Screen.mainScreenScale)
@@ -35,7 +35,8 @@ public final class TextureManager {
     /// Any name prefix to apply to all loaded textures (default = nil)
     /// If an actor has a name prefix of its own, this prefix will be applied first
     public var namePrefix: String?
-    /// ErrorMode to optionally set to apply in cases there is an image load failure for a texture. (default = IgnoreError)
+    /// ErrorMode to optionally set to apply in cases there is an image load failure for a texture.
+    /// (default = IgnoreError)
     /// This is considered only in DEBUG mode
     public var errorMode: ErrorMode = .ignore
 
@@ -43,7 +44,8 @@ public final class TextureManager {
 
     // MARK: - Init
 
-    internal init(imageLoader: TextureImageLoader = BundleTextureImageLoader(), errorHandler: TextureErrorHandler = DefaultTextureErrorHandler()) {
+    internal init(imageLoader: TextureImageLoader = BundleTextureImageLoader(),
+                  errorHandler: TextureErrorHandler = DefaultTextureErrorHandler()) {
         self.imageLoader = imageLoader
         self.errorHandler = errorHandler
     }
@@ -88,7 +90,7 @@ public final class TextureManager {
 
         guard let image = imageLoader.loadImageForTexture(named: name, scale: scale, format: format) else {
             guard scale > 1 else {
-              
+
                 #if DEBUG
                 let errorMessage = "Image with filename '\(name)' for a texture couldn't be found"
                 switch errorMode {
@@ -100,7 +102,7 @@ public final class TextureManager {
                     self.errorHandler.assert(errorMessage: errorMessage)
                 }
                 #endif
-              
+
                 return nil
             }
 
@@ -118,7 +120,7 @@ private class DefaultTextureErrorHandler :TextureErrorHandler {
     func log(errorMessage: String) {
         print(errorMessage)
     }
-    
+
     func assert(errorMessage: String) {
         assertionFailure(errorMessage)
     }

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -91,7 +91,6 @@ public final class TextureManager {
         guard let image = imageLoader.loadImageForTexture(named: name, scale: scale, format: format) else {
             guard scale > 1 else {
 
-                
                 #if DEBUG
                 let errorMessage = "Image with filename '\(name)' for a texture couldn't be found"
                 switch errorMode {

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -7,18 +7,15 @@
 import Foundation
 import CoreGraphics
 
-/**
-    This Enum decides how to handle Errors while loading images for a texture
-    - Note: Setting this only works in DEBUG mode
- 
-    - Remark:
-        - **ignore**: Ignores the error
-        - **log**: Logs the error with missing image info to the console
-        - **assert**: Throws an assertFailure for the error with missing image info
- */
+
+///    This Enum decides how to handle Errors while loading images for a texture.
+///    Setting this only works in DEBUG mode
 public enum ErrorMode {
+    ///Ignores the error
     case ignore
+    ///Logs the error with missing image info to the console
     case log
+    ///Throws an assertFailure for the error with missing image info
     case assert
 }
 
@@ -27,7 +24,7 @@ public final class TextureManager {
     /// The image loader that should be used (default = load from bundle)
     public var imageLoader: TextureImageLoader
     /// The Error Handler that should be used (default = DefaultTextureErrorHandler)
-    public var errorHandler: TextureErrorHandler
+    internal var errorHandler: TextureErrorHandler
     /// The default scale when loading textures (default = the main screen's scale)
     public var defaultScale: Int = Int(Screen.mainScreenScale)
     /// The default format when loading textures (default = PNG)

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -14,7 +14,7 @@ import CoreGraphics
     - Remark:
         - **ignore**: Ignores the error
         - **log**: Logs the error with missing image info to the console
-        - **assert**: Throws a assertFailure for the error with missing image info
+        - **assert**: Throws an assertFailure for the error with missing image info
  */
 public enum ErrorMode {
     case ignore

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -91,6 +91,7 @@ public final class TextureManager {
         guard let image = imageLoader.loadImageForTexture(named: name, scale: scale, format: format) else {
             guard scale > 1 else {
 
+                
                 #if DEBUG
                 let errorMessage = "Image with filename '\(name)' for a texture couldn't be found"
                 switch errorMode {

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -26,6 +26,8 @@ public enum ErrorMode {
 public final class TextureManager {
     /// The image loader that should be used (default = load from bundle)
     public var imageLoader: TextureImageLoader
+    /// The Error Handler that should be used (default implementation is provided in this class: DefaultTextureErrorHandler)
+    public var errorHandler: TextureErrorHandler
     /// The default scale when loading textures (default = the main screen's scale)
     public var defaultScale: Int = Int(Screen.mainScreenScale)
     /// The default format when loading textures (default = PNG)
@@ -41,8 +43,9 @@ public final class TextureManager {
 
     // MARK: - Init
 
-    internal init(imageLoader: TextureImageLoader = BundleTextureImageLoader()) {
+    internal init(imageLoader: TextureImageLoader = BundleTextureImageLoader(), errorHandler: TextureErrorHandler = DefaultTextureErrorHandler()) {
         self.imageLoader = imageLoader
+        self.errorHandler = errorHandler
     }
 
     // MARK: - Public
@@ -92,9 +95,9 @@ public final class TextureManager {
                     case .ignore:
                     break
                     case .log:
-                    print(errorMessage)
+                    self.errorHandler.log(errorMessage: errorMessage)
                     case .assert:
-                    assertionFailure(errorMessage)
+                    self.errorHandler.assert(errorMessage: errorMessage)
                 }
                 #endif
               
@@ -107,5 +110,16 @@ public final class TextureManager {
         let texture = LoadedTexture(image: image, scale: scale)
         cache[cacheKey] = texture
         return texture
+    }
+}
+
+/// The default implementation of the TextureErrorHandler protocol to be used by this class
+private class DefaultTextureErrorHandler :TextureErrorHandler {
+    func log(errorMessage: String) {
+        print(errorMessage)
+    }
+    
+    func assert(errorMessage: String) {
+        assertionFailure(errorMessage)
     }
 }

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -7,7 +7,15 @@
 import Foundation
 import CoreGraphics
 
-///
+/**
+    This Enum decides how to handle Errors while loading images for a texture
+    - Note: Setting this only works in DEBUG mode
+ 
+    - Remark:
+        - **ignore**: Ignores the error
+        - **log**: Logs the error with missing image info to the console
+        - **assert**: Throws a assertFailure for the error with missing image info
+ */
 public enum ErrorMode {
     case ignore
     case log

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -7,10 +7,11 @@
 import Foundation
 import CoreGraphics
 
+///
 public enum ErrorMode {
-  case IgnoreError
-  case LogError
-  case TriggerAssertOnError
+    case ignore
+    case log
+    case assert
 }
 
 /// Class that manages & faciliates the loading of textures for actors
@@ -26,7 +27,7 @@ public final class TextureManager {
     public var namePrefix: String?
     /// ErrorMode to optionally set to apply in cases there is an image load failure for a texture. (default = IgnoreError)
     /// This is considered only in DEBUG mode
-    public var errorMode: ErrorMode = .IgnoreError
+    public var errorMode: ErrorMode = .ignore
 
     internal private(set) var cache = [String : LoadedTexture]()
 
@@ -77,21 +78,19 @@ public final class TextureManager {
         guard let image = imageLoader.loadImageForTexture(named: name, scale: scale, format: format) else {
             guard scale > 1 else {
               
-              #if DEBUG
-              let errorMessage = "Image with filename '\(name)' for a texture couldn't be found"
-              switch errorMode {
-              case .IgnoreError:
-                break
-              case .LogError:
-                print(errorMessage)
-              case .TriggerAssertOnError:
-                assertionFailure(errorMessage)
-              default:
-                break
-              }
-              #endif
+                #if DEBUG
+                let errorMessage = "Image with filename '\(name)' for a texture couldn't be found"
+                switch errorMode {
+                    case .ignore:
+                    break
+                    case .log:
+                    print(errorMessage)
+                    case .assert:
+                    assertionFailure(errorMessage)
+                }
+                #endif
               
-              return nil
+                return nil
             }
 
             return load(texture, namePrefix: namePrefix, scale: scale - 1)

--- a/Sources/Core/Internal/TextureErrorHandler.swift
+++ b/Sources/Core/Internal/TextureErrorHandler.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol TextureErrorHandler {
+internal protocol TextureErrorHandler {
     func log(errorMessage: String)
     func assert(errorMessage: String)
 }

--- a/Sources/Core/Internal/TextureErrorHandler.swift
+++ b/Sources/Core/Internal/TextureErrorHandler.swift
@@ -1,0 +1,13 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  Copyright (c) Vijay Tholpadi 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+
+public protocol TextureErrorHandler {
+    func log(errorMessage: String)
+    func assert(errorMessage: String)
+}

--- a/Tests/ImagineEngineTests/Mocks/TextureErrorHandlerMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/TextureErrorHandlerMock.swift
@@ -10,15 +10,15 @@ import Foundation
 @testable import ImagineEngine
 
 class TextureErrorHandlerMock: TextureErrorHandler {
-    
+
     var didIgnore: Bool { return !didLog && !didAssert }
     var didLog = false
     var didAssert = false
-    
+
     func log(errorMessage: String) {
         didLog = true
     }
-    
+
     func assert(errorMessage: String) {
         didAssert = true
     }

--- a/Tests/ImagineEngineTests/Mocks/TextureErrorHandlerMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/TextureErrorHandlerMock.swift
@@ -1,17 +1,14 @@
-//
-//  TextureErrorHandlerMock.swift
-//  ImagineEngine
-//
-//  Created by Vijay on 21/11/17.
-//  Copyright © 2017 ImagineEngine. All rights reserved.
-//
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  Copyright (c) Vijay Tholpadi 2017
+ *  See LICENSE file for license
+ */
 
 import Foundation
 @testable import ImagineEngine
 
 class TextureErrorHandlerMock: TextureErrorHandler {
-
-    var didIgnore: Bool { return !didLog && !didAssert }
     var didLog = false
     var didAssert = false
 

--- a/Tests/ImagineEngineTests/Mocks/TextureErrorHandlerMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/TextureErrorHandlerMock.swift
@@ -1,0 +1,25 @@
+//
+//  TextureErrorHandlerMock.swift
+//  ImagineEngine
+//
+//  Created by Vijay on 21/11/17.
+//  Copyright © 2017 ImagineEngine. All rights reserved.
+//
+
+import Foundation
+@testable import ImagineEngine
+
+class TextureErrorHandlerMock: TextureErrorHandler {
+    
+    var didIgnore: Bool { return !didLog && !didAssert }
+    var didLog = false
+    var didAssert = false
+    
+    func log(errorMessage: String) {
+        didLog = true
+    }
+    
+    func assert(errorMessage: String) {
+        didAssert = true
+    }
+}

--- a/Tests/ImagineEngineTests/TextureManagerTests.swift
+++ b/Tests/ImagineEngineTests/TextureManagerTests.swift
@@ -71,27 +71,27 @@ class TextureManagerTests: XCTestCase {
         _ = manager.load(texture, namePrefix: "Second", scale: 1)
         XCTAssertEqual(imageLoader.imageNames, ["PrefixTexture.png", "PrefixSecondTexture.png"])
     }
-    
+
     func testIgnoresErrorWhenErrorModeIsIgnoreWhenLoadinTextureFails() {
         let texture = Texture(name: "nonExistentTexture")
         manager.errorMode = .ignore
-        
+
         _ = manager.load(texture, namePrefix: nil, scale: 1)
         XCTAssert(errorHandler.didIgnore)
     }
-    
+
     func testLogsErrorWhenErrorModeIsLogWhenLoadingTextureFailures() {
         let texture = Texture(name: "nonExistentTexture")
         manager.errorMode = .log
-        
+
         _ = manager.load(texture, namePrefix: nil, scale: 1)
         XCTAssert(errorHandler.didLog && !errorHandler.didAssert)
     }
-    
+
     func testAssertsErrorWhenErrorModeIsAssertWhenLoadingTextureFailures() {
         let texture = Texture(name: "nonExistentTexture")
         manager.errorMode = .assert
-        
+
         _ = manager.load(texture, namePrefix: nil, scale: 1)
         XCTAssert(!errorHandler.didLog && errorHandler.didAssert)
     }

--- a/Tests/ImagineEngineTests/TextureManagerTests.swift
+++ b/Tests/ImagineEngineTests/TextureManagerTests.swift
@@ -77,7 +77,8 @@ class TextureManagerTests: XCTestCase {
         manager.errorMode = .ignore
 
         _ = manager.load(texture, namePrefix: nil, scale: 1)
-        XCTAssert(errorHandler.didIgnore)
+        XCTAssertFalse(errorHandler.didLog, "Should not have logged")
+        XCTAssertFalse(errorHandler.didAssert, "Should not have asserted")
     }
 
     func testLogsErrorWhenErrorModeIsLogWhenLoadingTextureFailures() {
@@ -85,7 +86,8 @@ class TextureManagerTests: XCTestCase {
         manager.errorMode = .log
 
         _ = manager.load(texture, namePrefix: nil, scale: 1)
-        XCTAssert(errorHandler.didLog && !errorHandler.didAssert)
+        XCTAssertTrue(errorHandler.didLog, "Did not log")
+        XCTAssertFalse(errorHandler.didAssert, "Should not have asserted")
     }
 
     func testAssertsErrorWhenErrorModeIsAssertWhenLoadingTextureFailures() {
@@ -94,6 +96,8 @@ class TextureManagerTests: XCTestCase {
 
         _ = manager.load(texture, namePrefix: nil, scale: 1)
         XCTAssert(!errorHandler.didLog && errorHandler.didAssert)
+        XCTAssertTrue(errorHandler.didAssert, "Did not assert")
+        XCTAssertFalse(errorHandler.didLog, "Should not have logged")
     }
 
     // MARK: - Utilities


### PR DESCRIPTION
Issue number: #61 

@JohnSundell Could you throw some light on how this could be tested? Considering that the scenarios to be tested would be 
- Ensure there is no action when `IgnoreError` is selected
- Ensure there is logging when `LogError` is selected
- Ensure there is assert when `TriggerAssertOnError` is selected

I am not entirely confident of the changes without the tests.