### PR TITLE
SwiftLint: Enable most rules + fix codebase to match

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,20 +1,16 @@
+function_body_length: 50
+identifier_name:
+    excluded:
+        - x
+        - y
+
 disabled_rules:
-  - colon
-  - cyclomatic_complexity
-  - for_where
-  - force_cast
-  - function_body_length
-  - function_parameter_count
-  - identifier_name
-  - legacy_nsgeometry_functions
-  - line_length
-  - operator_whitespace
-  - redundant_optional_initialization
-  - trailing_newline
-  - trailing_whitespace
-  - type_body_length
-  - unused_closure_parameter
-  - vertical_parameter_alignment
+    - colon
+    - cyclomatic_complexity
+    - file_length
+    - for_where
+    - operator_whitespace
+    - type_body_length
 
 custom_rules:
   empty_line_after_guard_statement:

--- a/Documentation/Tutorials/2-Walkabout/FinalCode.swift
+++ b/Documentation/Tutorials/2-Walkabout/FinalCode.swift
@@ -25,7 +25,7 @@ class WalkaboutScene: Scene {
 
         var moveToken: ActionToken?
 
-        events.clicked.observe { scene, point in
+        events.clicked.observe { _, point in
             moveToken?.cancel()
 
             let speed: Metric = 100

--- a/Sources/Core/API/Action.swift
+++ b/Sources/Core/API/Action.swift
@@ -84,7 +84,7 @@ open class Action<Object> {
         if context.completionRatio < 1 {
             return .continueAfter(0)
         }
-        
+
         return .finished
     }
 }

--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -26,7 +26,8 @@ import Foundation
  *  scene.add(actor)
  *  ```
  */
-public final class Actor: SceneObject, InstanceHashable, ActionPerformer, Pluggable, ZIndexed, Movable, Rotatable, Scalable, Fadeable {
+public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
+                          Pluggable, ZIndexed, Movable, Rotatable, Scalable, Fadeable {
     /// The scene that the actor currently belongs to.
     public internal(set) weak var scene: Scene? { didSet { sceneDidChange() } }
     /// A collection of events that can be used to observe the actor.
@@ -77,7 +78,7 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer, Plugga
     private var velocityActionToken: ActionToken?
     private var animationActionToken: ActionToken?
     private var isUpdatingPosition = false
-    
+
     // MARK: - Initializer
 
     /// Initialize an instance of this class
@@ -156,7 +157,7 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer, Plugga
         isClickable = true
         scene?.add(ClickPlugin())
     }
-    
+
     // MARK: - Private
 
     private func sceneDidChange() {
@@ -175,7 +176,7 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer, Plugga
         let isOriginalUpdate = !isUpdatingPosition
         isUpdatingPosition = true
         updateRect()
-        
+
         guard isOriginalUpdate else {
             return
         }

--- a/Sources/Core/API/Animation.swift
+++ b/Sources/Core/API/Animation.swift
@@ -34,7 +34,7 @@ public struct Animation {
     /// Whether the actor's `textureNamePrefix` should be ignored for this animation
     public var ignoreTextureNamePrefix = false
     /// Any explicit scale that should be used when loading textures for this animation
-    public var textureScale: Int? = nil
+    public var textureScale: Int?
 
     private var identifier = ""
 }

--- a/Sources/Core/API/Block.swift
+++ b/Sources/Core/API/Block.swift
@@ -96,21 +96,26 @@ public final class Block: SceneObject, InstanceHashable, ActionPerformer, ZIndex
         segmentLayers.bottom.frame.origin.y = size.height - segmentLayers.bottom.frame.height
 
         let centerReplicatorLayer = ReplicatorLayer()
-        centerReplicatorLayer.frame.origin.y = segmentLayers.top.frame.height
-        centerReplicatorLayer.frame.size.width = size.width
-        centerReplicatorLayer.frame.size.height = size.height - segmentLayers.top.frame.height - segmentLayers.bottom.frame.height
+        centerReplicatorLayer.frame = Rect(
+            x: 0,
+            y: segmentLayers.top.frame.height,
+            width: size.width,
+            height: size.height - segmentLayers.top.frame.height - segmentLayers.bottom.frame.height
+        )
         centerReplicatorLayer.instanceTransform = CATransform3DMakeTranslation(0, segmentLayers.center.frame.height, 0)
         centerReplicatorLayer.masksToBounds = true
 
         if segmentLayers.center.frame.height > 0 {
-            centerReplicatorLayer.instanceCount = Int(ceil(centerReplicatorLayer.frame.height / segmentLayers.center.frame.height))
+            let fractionalInstanceCount = centerReplicatorLayer.frame.height / segmentLayers.center.frame.height
+            centerReplicatorLayer.instanceCount = Int(ceil(fractionalInstanceCount))
         }
 
         centerReplicatorLayer.addSublayer(segmentLayers.center)
         layer.addSublayer(centerReplicatorLayer)
     }
 
-    private func makeSegmentLayers(from textures: BlockTextureCollection, using textureManager: TextureManager) -> SegmentLayerCollection {
+    private func makeSegmentLayers(from textures: BlockTextureCollection,
+                                   using textureManager: TextureManager) -> SegmentLayerCollection {
         func loadTexture(_ texture: Texture?) -> LoadedTexture? {
             guard let texture = texture else {
                 return nil
@@ -221,7 +226,9 @@ public extension Block {
     /// Initialize an instance with a given size and the name of a texture collection
     /// See `BlockTextureCollection` for more information about how the names of
     /// individual textures are inferred.
-    convenience init(size: Size, textureCollectionName: String, textureScale: Int? = nil, textureFormat: TextureFormat? = nil) {
+    convenience init(size: Size, textureCollectionName: String,
+                     textureScale: Int? = nil,
+                     textureFormat: TextureFormat? = nil) {
         let textures = BlockTextureCollection(name: textureCollectionName, textureFormat: textureFormat)
         self.init(size: size, content: .collection(textures), textureScale: textureScale)
     }
@@ -229,7 +236,9 @@ public extension Block {
     /// Initialize an instance with a given size and the name of a sprite sheet to use for
     /// the block's textures. The texture for the sprite sheet will be cut into 9 identically
     /// sized pieces (3 x 3), which will be used to tile the block.
-    convenience init(size: Size, spriteSheetName: String, textureScale: Int? = nil, textureFormat: TextureFormat? = nil) {
+    convenience init(size: Size, spriteSheetName: String,
+                     textureScale: Int? = nil,
+                     textureFormat: TextureFormat? = nil) {
         let texture = Texture(name: spriteSheetName, format: textureFormat)
         self.init(size: size, content: .texture(texture), textureScale: textureScale)
     }
@@ -273,7 +282,7 @@ private extension Block {
             if let centerTexture = centerTexture {
                 let centerContentLayer = makeContentLayer(withTexture: centerTexture, contentRect: centerContentRect)
                 let centerTextureSize = centerContentLayer.frame.size
-                
+
                 let replicatorLayer = ReplicatorLayer()
                 replicatorLayer.frame.size.width = width - leftLayerSize.width - rightLayerSize.width
                 replicatorLayer.frame.size.height = centerTextureSize.height

--- a/Sources/Core/API/EventCollection.swift
+++ b/Sources/Core/API/EventCollection.swift
@@ -24,10 +24,12 @@ public class EventCollection<Object: AnyObject> {
     /// Make a new event with an identifier for the event's subject
     /// Call this method within an extension defining a custom event.
     /// For more information, see the documentation for `Event`.
-    public func makeEvent<Subject>(named name: StaticString = #function, withSubjectIdentifier subjectIdentifier: String) -> Event<Object, Subject> {
+    public func makeEvent<Subject>(named name: StaticString = #function,
+                                   withSubjectIdentifier subjectIdentifier: String) -> Event<Object, Subject> {
         let name = "\(name)-\(subjectIdentifier)"
 
         if let event = events[name] {
+            // swiftlint:disable:next force_cast
             return event as! Event<Object, Subject>
         }
 
@@ -39,7 +41,8 @@ public class EventCollection<Object: AnyObject> {
     /// Make a new event with a subject
     /// Call this method within an extension defining a custom event.
     /// For more information, see the documentation for `Event`.
-    public func makeEvent<Subject: AnyObject>(named name: StaticString = #function, withSubject subject: Subject) -> Event<Object, Subject> {
+    public func makeEvent<Subject: AnyObject>(named name: StaticString = #function,
+                                              withSubject subject: Subject) -> Event<Object, Subject> {
         return makeEvent(named: name, withSubjectIdentifier: String(describing: ObjectIdentifier(subject)))
     }
 

--- a/Sources/Core/API/Game.swift
+++ b/Sources/Core/API/Game.swift
@@ -33,7 +33,10 @@ open class Game {
         self.init(view: view, scene: scene, displayLink: DisplayLink())
     }
 
-    internal init(view: GameView, scene: Scene, displayLink: DisplayLinkProtocol, dateProvider: @escaping () -> Date = Date.init) {
+    internal init(view: GameView,
+                  scene: Scene,
+                  displayLink: DisplayLinkProtocol,
+                  dateProvider: @escaping () -> Date = Date.init) {
         self.view = view
         self.scene = scene
         self.displayLink = displayLink
@@ -67,7 +70,7 @@ open class Game {
     }
 
     // MARK: - Private
-    
+
     private func sceneDidChange(from previousScene: Scene?) {
         previousScene?.deactivate()
 

--- a/Sources/Core/API/MoveAction.swift
+++ b/Sources/Core/API/MoveAction.swift
@@ -23,7 +23,7 @@ public final class MoveAction<Object: Movable>: Action<Object> {
         self.mode = .vector(vector)
         super.init(duration: duration)
     }
-    
+
     public override func start(for object: Object) {
         vector = nil
         previousCompletionRatio = nil

--- a/Sources/Core/API/Pluggable.swift
+++ b/Sources/Core/API/Pluggable.swift
@@ -19,7 +19,8 @@ public protocol Pluggable: class {
 
     /// Add a plugin to this object or reuse an existing instance of the same type (default)
     /// - Returns: The plugin that was either added or reused
-    func add<P: Plugin>(_ plugin: @autoclosure () -> P, reuseExistingOfSameType: Bool) -> P where P.Object == PluginTarget
+    func add<P: Plugin>(_ plugin: @autoclosure () -> P,
+                        reuseExistingOfSameType: Bool) -> P where P.Object == PluginTarget
 
     /// Retrive an array of plugins added to this object
     /// - Returns: An array of plugins of specified type that were previously added to this object

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -4,7 +4,7 @@
  *  See LICENSE file for license
  */
 
-import Foundation   
+import Foundation
 
 /**
  *  Class representing a scene in an Imagine Engine game
@@ -49,7 +49,7 @@ open class Scene: Pluggable, Activatable {
     private let layer = Layer()
     private var grid = Grid()
     private let pluginManager = PluginManager()
-        
+
     // MARK: - Initializer
 
     /// Initialize an instance with a given size
@@ -107,7 +107,7 @@ open class Scene: Pluggable, Activatable {
     /// Add an actor to the scene
     public func add(_ actor: Actor) {
         actor.scene = self
-        
+
         grid.add(actor, in: self)
         layer.addSublayer(actor.layer)
         game.map(actor.activate)
@@ -178,10 +178,10 @@ open class Scene: Pluggable, Activatable {
     }
 
     // MARK: - Activatable
-    
+
     internal func activate(in game: Game) {
         self.game = game
-        
+
         game.view.makeLayerIfNeeded().addSublayer(layer)
 
         camera.activate(in: game)
@@ -202,7 +202,7 @@ open class Scene: Pluggable, Activatable {
 
         activate()
     }
-    
+
     internal func deactivate() {
         layer.removeFromSuperlayer()
 
@@ -232,7 +232,7 @@ open class Scene: Pluggable, Activatable {
         let wasWithinScene = actor.isWithinScene
         let sceneRect = Rect(origin: .zero, size: size)
         actor.isWithinScene = actor.rect.intersects(sceneRect)
-        
+
         if !wasWithinScene && actor.isWithinScene {
             actor.events.enteredScene.trigger()
         } else if wasWithinScene && !actor.isWithinScene {

--- a/Sources/Core/API/TextureManager.swift
+++ b/Sources/Core/API/TextureManager.swift
@@ -29,7 +29,10 @@ public final class TextureManager {
 
     // MARK: - Public
 
-    public func preloadTexture(named name: String, scale: Int? = nil, format: TextureFormat? = nil, onQueue queue: DispatchQueue = .main) {
+    public func preloadTexture(named name: String,
+                               scale: Int? = nil,
+                               format: TextureFormat? = nil,
+                               onQueue queue: DispatchQueue = .main) {
         queue.async {
             _ = self.load(Texture(name: name, format: format), namePrefix: nil, scale: scale)
         }

--- a/Sources/Core/API/Timeline.swift
+++ b/Sources/Core/API/Timeline.swift
@@ -40,13 +40,15 @@ public final class Timeline: Activatable {
     private var pauseInterval: TimeInterval = 0
 
     /// Run a closure once after a given time interval
-    @discardableResult public func after(interval: TimeInterval, run closure: @escaping () -> Void) -> CancellationToken {
+    @discardableResult public func after(interval: TimeInterval,
+                                         run closure: @escaping () -> Void) -> CancellationToken {
         let updatable = ClosureUpdatable(closure: closure)
         return schedule(updatable, delay: interval)
     }
 
     /// Repeat a closure by a given time interval, until it's cancelled by the returned token
-    @discardableResult public func `repeat`(withInterval interval: TimeInterval, closure: @escaping () -> Void) -> CancellationToken {
+    @discardableResult public func `repeat`(withInterval interval: TimeInterval,
+                                            closure: @escaping () -> Void) -> CancellationToken {
         let updatable = ClosureUpdatable { () -> UpdateOutcome in
             closure()
             return .continueAfter(interval)
@@ -211,15 +213,19 @@ private extension Timeline {
 public extension Timeline {
     /// Run a closure after a given time interval, using an object that will be passed into the closure when run.
     /// The object won't be retained, and if it's released before the interval has passed, the closure won't be run.
-    @discardableResult func after<T: AnyObject>(interval: TimeInterval, using object: T, run closure: @escaping (T) -> Void) -> CancellationToken {
+    @discardableResult func after<T: AnyObject>(interval: TimeInterval,
+                                                using object: T,
+                                                run closure: @escaping (T) -> Void) -> CancellationToken {
         return after(interval: interval) { [weak object] in
             object.map(closure)
         }
     }
 
     /// Repeat a closure by a given time interval, using an object that will be passed into the closure when run.
-    /// The closure will be repeatedly run until either the passed object is deallocated, or until the returned token is cancelled.
-    @discardableResult func `repeat`<T: AnyObject>(withInterval interval: TimeInterval, using object: T, closure: @escaping (T) -> Void) -> CancellationToken {
+    /// The closure will be repeated until either its object is released, or until cancelled using the returned token.
+    @discardableResult func `repeat`<T: AnyObject>(withInterval interval: TimeInterval,
+                                                   using object: T,
+                                                   closure: @escaping (T) -> Void) -> CancellationToken {
         let updatable = ClosureUpdatable { [weak object] () -> UpdateOutcome in
             guard let object = object else {
                 return .finished

--- a/Sources/Core/Internal/DisplayLink-macOS.swift
+++ b/Sources/Core/Internal/DisplayLink-macOS.swift
@@ -11,34 +11,40 @@ import CoreVideo
 internal final class DisplayLink: DisplayLinkProtocol {
     var callback: () -> Void = {}
     private var link: CVDisplayLink?
-    
+
     deinit {
         guard let link = link else {
             return
         }
-        
+
         CVDisplayLinkStop(link)
     }
-    
+
     func activate() {
         CVDisplayLinkCreateWithActiveCGDisplays(&link)
-        
+
         guard let link = link else {
             return
         }
-        
+
         let opaquePointerToSelf = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
         CVDisplayLinkSetOutputCallback(link, _imageEngineDisplayLinkCallback, opaquePointerToSelf)
-        
+
         CVDisplayLinkStart(link)
     }
-    
+
     @objc func screenDidRender() {
         DispatchQueue.main.async(execute: callback)
     }
 }
 
-private func _imageEngineDisplayLinkCallback(displayLink: CVDisplayLink, _ now: UnsafePointer<CVTimeStamp>, _ outputTime: UnsafePointer<CVTimeStamp>, _ flagsIn: CVOptionFlags, _ flagsOut: UnsafeMutablePointer<CVOptionFlags>, _ displayLinkContext: UnsafeMutableRawPointer?) -> CVReturn {
+// swiftlint:disable:next function_parameter_count
+private func _imageEngineDisplayLinkCallback(displayLink: CVDisplayLink,
+                                             _ now: UnsafePointer<CVTimeStamp>,
+                                             _ outputTime: UnsafePointer<CVTimeStamp>,
+                                             _ flagsIn: CVOptionFlags,
+                                             _ flagsOut: UnsafeMutablePointer<CVOptionFlags>,
+                                             _ displayLinkContext: UnsafeMutableRawPointer?) -> CVReturn {
     unsafeBitCast(displayLinkContext, to: DisplayLink.self).screenDidRender()
     return kCVReturnSuccess
 }

--- a/Sources/Core/Internal/EdgeInsets-macOS.swift
+++ b/Sources/Core/Internal/EdgeInsets-macOS.swift
@@ -8,6 +8,7 @@ import Cocoa
 
 extension EdgeInsets: Equatable {
     public static func ==(lhs: EdgeInsets, rhs: EdgeInsets) -> Bool {
+        // swiftlint:disable:next legacy_nsgeometry_functions
         return NSEdgeInsetsEqual(lhs, rhs)
     }
 }

--- a/Sources/Core/Internal/Image-macOS.swift
+++ b/Sources/Core/Internal/Image-macOS.swift
@@ -11,7 +11,7 @@ internal extension Image {
     var cgImage: CGImage? {
         return cgImage(forProposedRect: nil, context: nil, hints: nil)
     }
-    
+
     var scale: CGFloat {
         // TODO: find a better way of figuring out the image scale factor on macOS
         return Screen.mainScreenScale

--- a/Sources/Core/Internal/PluginManager.swift
+++ b/Sources/Core/Internal/PluginManager.swift
@@ -17,6 +17,7 @@ internal final class PluginManager: Activatable {
 
         if reuseExistingOfSameType {
             if let existingPlugin = plugins[typeIdentifier]?.first?.value {
+                // swiftlint:disable:next force_cast
                 return existingPlugin.wrapped as! P
             }
         }
@@ -36,9 +37,12 @@ internal final class PluginManager: Activatable {
 
     func plugins<P: Plugin>(ofType type: P.Type) -> [P] {
         let typeIdentifier = TypeIdentifier(type: type)
-
         let pluginsOfType = plugins[typeIdentifier, default: [:]].values
-        return pluginsOfType.map { $0.wrapped as! P }
+
+        return pluginsOfType.map { wrapper in
+            // swiftlint:disable:next force_cast
+            wrapper.wrapped as! P
+        }
     }
 
     func remove<P: Plugin>(_ plugin: P, from object: P.Object) {

--- a/Sources/Integrations/AppKit/GameViewController-macOS.swift
+++ b/Sources/Integrations/AppKit/GameViewController-macOS.swift
@@ -17,82 +17,82 @@ import Cocoa
 public class GameViewController: NSViewController {
     /// The game that the view controller is managing
     public let game: Game
-    
+
     private let notificationCenter: NotificationCenter
     private var gameWasAutoPaused = false
-    
+
     // MARK: - Lifecycle
-    
+
     /// Initialize an instance of this class with a game
     public init(game: Game, notificationCenter: NotificationCenter = .default) {
         self.game = game
         self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required public init?(coder decoder: NSCoder) {
         game = Game(size: .zero, scene: Scene(size: .zero))
         notificationCenter = .default
         super.init(coder: decoder)
     }
-    
+
     deinit {
         notificationCenter.removeObserver(self)
     }
-    
+
     // MARK: - UIViewController
-    
+
     public override func loadView() {
         view = game.view
         view.wantsLayer = true
     }
-    
+
     public override func viewDidAppear() {
         super.viewDidAppear()
-        
+
         game.scene.isPaused = false
         game.updateActivationStatus()
-        
+
         notificationCenter.addObserver(self,
             selector: #selector(applicationDidBecomeActive),
             name: NSApplication.didBecomeActiveNotification,
             object: nil
         )
-        
+
         notificationCenter.addObserver(self,
             selector: #selector(applicationWillBecomeInactive),
             name: NSApplication.willBecomeActiveNotification,
             object: nil
         )
     }
-    
+
     public override func viewDidDisappear() {
         super.viewDidDisappear()
-        
+
         game.scene.isPaused = true
         notificationCenter.removeObserver(self)
     }
-    
+
     public override func viewDidLayout() {
         super.viewDidLayout()
         game.view.frame = view.bounds
     }
-    
+
     // MARK: - Observations
-    
+
     @objc private func applicationDidBecomeActive() {
         if gameWasAutoPaused {
             game.scene.isPaused = false
         }
-        
+
         gameWasAutoPaused = false
     }
-    
+
     @objc private func applicationWillBecomeInactive() {
         guard !game.scene.isPaused else {
             return
         }
-        
+
         game.scene.isPaused = true
         gameWasAutoPaused = true
     }

--- a/Sources/Integrations/AppKit/GameWindowController.swift
+++ b/Sources/Integrations/AppKit/GameWindowController.swift
@@ -24,7 +24,7 @@ public class GameWindowController: NSWindowController {
             backing: .buffered,
             defer: false
         )
-        
+
         super.init(window: window)
 
         contentViewController = viewController

--- a/Sources/Integrations/UIKit/GameWindow.swift
+++ b/Sources/Integrations/UIKit/GameWindow.swift
@@ -19,7 +19,7 @@ public class GameWindow: UIWindow {
         super.init(frame: frame)
         rootViewController = viewController
     }
-    
+
     required public init?(coder decoder: NSCoder) {
         viewController = GameViewController(scene: Scene(size: .zero))
         super.init(coder: decoder)

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -175,13 +175,13 @@ final class ActorTests: XCTestCase {
 
         actor.position.y = 600
         XCTAssertEqual(actor.position.y, 450)
-        
+
         // Set actor scale
         actor.scale = 0.5
 
         actor.position.x = 500
         XCTAssertEqual(actor.position.x, 475)
-        
+
         actor.position.y = 600
         XCTAssertEqual(actor.position.y, 475)
 
@@ -210,7 +210,7 @@ final class ActorTests: XCTestCase {
         // Approaching from the right should stop the actor at the block's right edge
         actor.position = Point(x: -130, y: 0)
         XCTAssertEqual(actor.position.x, -200)
-        
+
         // Approaching from the top should stop the actor at the block's top edge
         actor.position = Point(x: 0, y: -130)
         XCTAssertEqual(actor.position.y, -200)
@@ -275,7 +275,7 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(oldPositions, [.zero, Point(x: 100, y: 0)])
         XCTAssertEqual(newPositions, [Point(x: 100, y: 0), Point(x: 100, y: 50)])
     }
-    
+
     func testEnteredScene() {
         // Create actor and place in center of scene
         let actor = Actor()
@@ -284,12 +284,12 @@ final class ActorTests: XCTestCase {
 
         var enterSceneCount = 0
         actor.events.enteredScene.observe { enterSceneCount += 1 }
-        
+
         // Move actor outside scene
         actor.position.x = -100
         XCTAssertFalse(actor.isWithinScene)
         XCTAssertEqual(enterSceneCount, 0)
-        
+
         // Now move actor back into scene
         actor.position.x = 0
         XCTAssertTrue(actor.isWithinScene)

--- a/Tests/ImagineEngineTests/BundleTextureImageLoaderTests.swift
+++ b/Tests/ImagineEngineTests/BundleTextureImageLoaderTests.swift
@@ -17,7 +17,7 @@ class BundleTextureImageLoaderTests: XCTestCase {
 
         XCTAssertEqual(bundle.resourceNames, ["texture.png", "ground@2x.jpg"])
     }
-    
+
     func testLoadsPNGImage() {
         let loader = BundleTextureImageLoader(bundle: Bundle(for: type(of: self)))
         let loadedImage = loader.loadImageForTexture(named: "sample", scale: 1, format: .png)!

--- a/Tests/ImagineEngineTests/Utilities/Assert.swift
+++ b/Tests/ImagineEngineTests/Utilities/Assert.swift
@@ -47,9 +47,9 @@ public func assert<T, E: Error>(at file: StaticString = #file,
  *  - closure: The closure that should thrown an error
  */
 public func assertErrorThrown<T, E: Error>(at file: StaticString = #file,
-                              line: UInt = #line,
-                              _ errorExpression: @autoclosure () -> E,
-                              by closure: () throws -> T) where E: Equatable {
+                                           line: UInt = #line,
+                                           _ errorExpression: @autoclosure () -> E,
+                                           by closure: () throws -> T) where E: Equatable {
     assert(at: file, line: line, try closure(), throwsError: errorExpression)
 }
 


### PR DESCRIPTION
A lot of SwiftLint rules have now been enabled. They were initially disabled to enable SwiftLint integration, but now it’s time to enable them and fix all warnings and errors that they result in.

Most fixes are removal of whitespace and shortening of lines, and at some places local disabling of rules had to be inserted (when force casting has to be used).