### PR TITLE
CI: Use xcpretty to format xcodebuild output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'danger'
 gem 'danger-swiftlint'
+gem 'xcpretty'

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 
-# Run tests on macOS + tvOS
-xcodebuild clean test -project ImagineEngine.xcodeproj -scheme ImagineEngine-macOS -destination "platform=OS X" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
-xcodebuild clean test -project ImagineEngine.xcodeproj -scheme ImagineEngine-tvOS -destination "platform=tvOS Simulator,name=Apple TV 1080p" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+# Run tests on macOS
+xcodebuild clean test \
+    -project ImagineEngine.xcodeproj \
+    -scheme ImagineEngine-macOS \
+    -destination "platform=OS X" \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    ONLY_ACTIVE_ARCH=NO \
+    | xcpretty
 
-# Run danger
+# Run tests on tvOS
+xcodebuild clean test \
+    -project ImagineEngine.xcodeproj \
+    -scheme ImagineEngine-tvOS \
+    -destination "platform=tvOS Simulator,name=Apple TV" \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    ONLY_ACTIVE_ARCH=NO \
+    | xcpretty
+
+# Run Danger
 chruby 2.3.1
 bundle install
 bundle exec danger


### PR DESCRIPTION
By default, xcodebuild generates a “wall of text” as its output, so let’s use xcpretty to make it a lot more readable. The build commands have now also been split up on multiple lines to make them easier to read.