### PR TITLE
CI: Use xcpretty with pipefail

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -20,9 +20,12 @@ function test_tvOS {
         ONLY_ACTIVE_ARCH=NO
 }
 
+# Make subcommands fail the build if they fail
+set -eo pipefail
+
 # Run tests on macOS + tvOS
-set -o pipefail && test_macOS | xcpretty
-set -o pipefail && test_tvOS | xcpretty
+test_macOS | xcpretty
+test_tvOS | xcpretty
 
 # Run Danger
 chruby 2.3.1

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
 
-# Run tests on macOS
-xcodebuild clean test \
-    -project ImagineEngine.xcodeproj \
-    -scheme ImagineEngine-macOS \
-    -destination "platform=OS X" \
-    CODE_SIGN_IDENTITY="" \
-    CODE_SIGNING_REQUIRED=NO \
-    ONLY_ACTIVE_ARCH=NO \
-    | xcpretty
+function test_macOS {
+    xcodebuild clean test \
+        -project ImagineEngine.xcodeproj \
+        -scheme ImagineEngine-macOS \
+        -destination "platform=OS X" \
+        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_REQUIRED=NO \
+        ONLY_ACTIVE_ARCH=NO
+}
 
-# Run tests on tvOS
-xcodebuild clean test \
-    -project ImagineEngine.xcodeproj \
-    -scheme ImagineEngine-tvOS \
-    -destination "platform=tvOS Simulator,name=Apple TV" \
-    CODE_SIGN_IDENTITY="" \
-    CODE_SIGNING_REQUIRED=NO \
-    ONLY_ACTIVE_ARCH=NO \
-    | xcpretty
+function test_tvOS {
+    xcodebuild clean test \
+        -project ImagineEngine.xcodeproj \
+        -scheme ImagineEngine-tvOS \
+        -destination "platform=tvOS Simulator,name=Apple TV" \
+        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_REQUIRED=NO \
+        ONLY_ACTIVE_ARCH=NO
+}
+
+# Run tests on macOS + tvOS
+set -o pipefail && test_macOS | xcpretty
+set -o pipefail && test_tvOS | xcpretty
 
 # Run Danger
 chruby 2.3.1


### PR DESCRIPTION
To enable the build to fail when a macOS or tvOS test fails.