### PR TITLE
CI: Add Danger warnings for merge commits & missing tests

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -17,3 +17,13 @@ end
 if github.pr_body.length == 0
     warn "Please add a decription to your PR to make it easier to review 👌"
 end
+
+# Encourage rebases instead of including merge commits
+if git.commits.any? { |c| c.message =~ /^Merge branch 'master'/ }
+  warn "Please rebase to get rid of the merge commits in this PR 🙏"
+end
+
+# If changes have been made in sources, encourage tests
+if !git.modified_files.grep(/Sources/).empty? && git.modified_files.grep(/Tests/).empty?
+    warn "Remember to write tests in case you have added a new API or fixed a bug. Feel free to ask for help if you need it 👍"
+end


### PR DESCRIPTION
This change introduces two new Danger warnings, one if a PR includes merge commits (which we want to avoid in order to get a somewhat clean Git history), and one in case the `Sources/` folder has been modified, but the `Tests/` folder hasn’t. Note that none of these prevent a merge, they’re just friendly suggestions.