### PR TITLE
EventCollection: Enable custom events to be created with a subject type

### DIFF
--- a/Sources/Core/API/EventCollection.swift
+++ b/Sources/Core/API/EventCollection.swift
@@ -49,7 +49,7 @@ public class EventCollection<Object: AnyObject> {
     /// Make a new event without a subject
     /// Call this method within an extension defining a custom event.
     /// For more information, see the documentation for `Event`.
-    public func makeEvent(named name: StaticString = #function) -> Event<Object, Void> {
+    public func makeEvent<Subject: AnyObject>(named name: StaticString = #function) -> Event<Object, Subject> {
         return makeEvent(named: name, withSubjectIdentifier: "Void")
     }
 }

--- a/Sources/Core/API/EventCollection.swift
+++ b/Sources/Core/API/EventCollection.swift
@@ -46,7 +46,7 @@ public class EventCollection<Object: AnyObject> {
         return makeEvent(named: name, withSubjectIdentifier: String(describing: ObjectIdentifier(subject)))
     }
 
-    /// Make a new event without a subject
+    /// Make a new event that is not bound to a specific subject
     /// Call this method within an extension defining a custom event.
     /// For more information, see the documentation for `Event`.
     public func makeEvent<Subject>(named name: StaticString = #function) -> Event<Object, Subject> {

--- a/Sources/Core/API/EventCollection.swift
+++ b/Sources/Core/API/EventCollection.swift
@@ -49,7 +49,7 @@ public class EventCollection<Object: AnyObject> {
     /// Make a new event without a subject
     /// Call this method within an extension defining a custom event.
     /// For more information, see the documentation for `Event`.
-    public func makeEvent<Subject: AnyObject>(named name: StaticString = #function) -> Event<Object, Subject> {
+    public func makeEvent<Subject>(named name: StaticString = #function) -> Event<Object, Subject> {
         return makeEvent(named: name, withSubjectIdentifier: "Void")
     }
 }

--- a/Tests/ImagineEngineTests/EventTests.swift
+++ b/Tests/ImagineEngineTests/EventTests.swift
@@ -12,6 +12,10 @@ private extension EventCollection where Object == Actor {
     var testEvent: Event<Actor, Point> {
         return makeEvent(withSubjectIdentifier: "subject")
     }
+
+    var testEventWithoutSubjectIdentifier: Event<Actor, Size> {
+        return makeEvent()
+    }
 }
 
 final class EventTests: XCTestCase {
@@ -33,6 +37,26 @@ final class EventTests: XCTestCase {
         event.trigger(with: Point(x: 200, y: 100))
         assertSameInstance(observedActor, actor)
         XCTAssertEqual(observedPoint, Point(x: 200, y: 100))
+    }
+
+    func testMakingAndObservingEventWithoutSubjectIdentifier() {
+        let actor = Actor()
+        let event = actor.events.testEventWithoutSubjectIdentifier
+
+        // Accessing the event again should return the same instance
+        assertSameInstance(event, actor.events.testEventWithoutSubjectIdentifier)
+
+        var observedActor: Actor?
+        var observedSize: Size?
+
+        event.observe {
+            observedActor = $0
+            observedSize = $1
+        }
+
+        event.trigger(with: Size(width: 200, height: 100))
+        assertSameInstance(observedActor, actor)
+        XCTAssertEqual(observedSize, Size(width: 200, height: 100))
     }
 
     func testAddingAndRemovingObserver() {


### PR DESCRIPTION
Currently, it’s only possible to make custom events with a subject type if you also have a subject identifier. While this works for cases where you want to make the observation conditional on the subject, for events that only pass a subject when observed this is not sufficient. This change fixes this by allowing any subject type to be used with a custom event.

(Tests initially omitted to test the new Danger warning)