### PR TITLE
Added new function addLayer to SceneObject

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -83,7 +83,13 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
 
     /// Initialize an instance of this class
     public init() {}
-
+    
+    // MARK: - SceneObject
+    
+    func addLayer(to superlayer: Layer) {
+        superlayer.addSublayer(layer)
+    }
+    
     // MARK: - ActionPerformer
 
     @discardableResult public func perform(_ action: Action<Actor>) -> ActionToken {

--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -83,13 +83,13 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
 
     /// Initialize an instance of this class
     public init() {}
-    
+
     // MARK: - SceneObject
-    
-    func addLayer(to superlayer: Layer) {
+
+    internal func addLayer(to superlayer: Layer) {
         superlayer.addSublayer(layer)
     }
-    
+
     // MARK: - ActionPerformer
 
     @discardableResult public func perform(_ action: Action<Actor>) -> ActionToken {

--- a/Sources/Core/API/Block.swift
+++ b/Sources/Core/API/Block.swift
@@ -55,6 +55,12 @@ public final class Block: SceneObject, InstanceHashable, ActionPerformer, ZIndex
     public func remove() {
         scene?.remove(self)
     }
+    
+    // MARK: - SceneObject
+    
+    func addLayer(to superlayer: Layer) {
+        superlayer.addSublayer(layer)
+    }
 
     // MARK: - ActionPerformer
 

--- a/Sources/Core/API/Block.swift
+++ b/Sources/Core/API/Block.swift
@@ -55,10 +55,10 @@ public final class Block: SceneObject, InstanceHashable, ActionPerformer, ZIndex
     public func remove() {
         scene?.remove(self)
     }
-    
+
     // MARK: - SceneObject
-    
-    func addLayer(to superlayer: Layer) {
+
+    internal func addLayer(to superlayer: Layer) {
         superlayer.addSublayer(layer)
     }
 

--- a/Sources/Core/API/Label.swift
+++ b/Sources/Core/API/Label.swift
@@ -52,10 +52,10 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, ZIndex
 
         fontDidChange()
     }
-    
+
     // MARK: - SceneObject
-    
-    func addLayer(to superlayer: Layer) {
+
+    internal func addLayer(to superlayer: Layer) {
         superlayer.addSublayer(layer)
     }
 

--- a/Sources/Core/API/Label.swift
+++ b/Sources/Core/API/Label.swift
@@ -52,6 +52,12 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, ZIndex
 
         fontDidChange()
     }
+    
+    // MARK: - SceneObject
+    
+    func addLayer(to superlayer: Layer) {
+        superlayer.addSublayer(layer)
+    }
 
     // MARK: - ActionPerformer
 

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -109,7 +109,7 @@ open class Scene: Pluggable, Activatable {
         actor.scene = self
 
         grid.add(actor, in: self)
-        layer.addSublayer(actor.layer)
+        actor.addLayer(to: layer)
         game.map(actor.activate)
     }
 
@@ -131,7 +131,7 @@ open class Scene: Pluggable, Activatable {
         block.scene = self
 
         grid.add(block)
-        layer.addSublayer(block.layer)
+        block.addLayer(to: layer)
         game.map(block.activate)
     }
 
@@ -148,7 +148,7 @@ open class Scene: Pluggable, Activatable {
         label.scene = self
 
         grid.add(label)
-        layer.addSublayer(label.layer)
+        label.addLayer(to: layer)
         game.map(label.activate)
     }
 

--- a/Sources/Core/Internal/SceneObject.swift
+++ b/Sources/Core/Internal/SceneObject.swift
@@ -8,4 +8,5 @@ import Foundation
 
 internal protocol SceneObject: Activatable {
     var scene: Scene? { get set }
+    func addLayer(to superlayer: Layer)
 }


### PR DESCRIPTION
`SceneObject`s are now responsible for adding themselves to the scene layer.
This change is needed to support new types of scene objects that uses custom layers. See issue #85 