### PR TITLE
Timeline: Enable setting a repeat mode when using the repeat API

### DIFF
--- a/Sources/Core/API/Timeline.swift
+++ b/Sources/Core/API/Timeline.swift
@@ -46,7 +46,7 @@ public final class Timeline: Activatable {
         return schedule(updatable, delay: interval)
     }
 
-    /// Repeat a closure by a given time interval, until it's cancelled by the returned token
+    /// Repeat a closure by a given time interval with a certain mode, until it's cancelled by the returned token
     @discardableResult public func `repeat`(withInterval interval: TimeInterval,
                                             mode: RepeatMode = .forever,
                                             closure: @escaping () -> Void) -> CancellationToken {
@@ -223,7 +223,8 @@ public extension Timeline {
     }
 
     /// Repeat a closure by a given time interval, using an object that will be passed into the closure when run.
-    /// The closure will be repeated until either its object is released, or until cancelled using the returned token.
+    /// The closure will be repeated according to the specified repeat mode, either its object is released, or until
+    /// cancelled using the returned token.
     @discardableResult func `repeat`<T: AnyObject>(withInterval interval: TimeInterval,
                                                    using object: T,
                                                    mode: RepeatMode = .forever,

--- a/Sources/Core/API/Timeline.swift
+++ b/Sources/Core/API/Timeline.swift
@@ -48,8 +48,9 @@ public final class Timeline: Activatable {
 
     /// Repeat a closure by a given time interval, until it's cancelled by the returned token
     @discardableResult public func `repeat`(withInterval interval: TimeInterval,
+                                            mode: RepeatMode = .forever,
                                             closure: @escaping () -> Void) -> CancellationToken {
-        let updatable = ClosureUpdatable { () -> UpdateOutcome in
+        let updatable = ClosureUpdatable(repeatMode: mode) { () -> UpdateOutcome in
             closure()
             return .continueAfter(interval)
         }
@@ -225,8 +226,9 @@ public extension Timeline {
     /// The closure will be repeated until either its object is released, or until cancelled using the returned token.
     @discardableResult func `repeat`<T: AnyObject>(withInterval interval: TimeInterval,
                                                    using object: T,
+                                                   mode: RepeatMode = .forever,
                                                    closure: @escaping (T) -> Void) -> CancellationToken {
-        let updatable = ClosureUpdatable { [weak object] () -> UpdateOutcome in
+        let updatable = ClosureUpdatable(repeatMode: mode) { [weak object] () -> UpdateOutcome in
             guard let object = object else {
                 return .finished
             }

--- a/Sources/Core/Internal/ClosureUpdatable.swift
+++ b/Sources/Core/Internal/ClosureUpdatable.swift
@@ -9,6 +9,8 @@ import Foundation
 internal final class ClosureUpdatable: Updatable {
     private let closure: () -> UpdateOutcome
 
+    // MARK: - Initializers
+
     init(closure: @escaping () -> Void) {
         self.closure = {
             closure()
@@ -16,9 +18,26 @@ internal final class ClosureUpdatable: Updatable {
         }
     }
 
-    init(closure: @escaping () -> UpdateOutcome) {
-        self.closure = closure
+    init(repeatMode: RepeatMode, closure: @escaping () -> UpdateOutcome) {
+        var repeatMode = repeatMode
+
+        self.closure = {
+            switch repeatMode {
+            case .forever:
+                break
+            case .times(let count):
+                guard count > 0 else {
+                    return .finished
+                }
+
+                repeatMode = .times(count - 1)
+            }
+
+            return closure()
+        }
     }
+
+    // MARK: - Updatable
 
     func update(currentTime: TimeInterval) -> UpdateOutcome {
         return closure()

--- a/Tests/ImagineEngineTests/TimelineTests.swift
+++ b/Tests/ImagineEngineTests/TimelineTests.swift
@@ -99,4 +99,25 @@ final class TimelineTests: XCTestCase {
         actor = Actor()
         XCTAssertNil(passedActor)
     }
+
+    func testRepeatingClosureASetNumberOfTimes() {
+        var runCount = 0
+
+        game.scene.timeline.repeat(withInterval: 2, mode: .times(2)) {
+            runCount += 1
+        }
+
+        game.timeTraveler.travel(by: 2)
+        game.update()
+        XCTAssertEqual(runCount, 1)
+
+        game.timeTraveler.travel(by: 2)
+        game.update()
+        XCTAssertEqual(runCount, 2)
+
+        // The third time the event shouldn't be repeated anymore
+        game.timeTraveler.travel(by: 2)
+        game.update()
+        XCTAssertEqual(runCount, 2)
+    }
 }


### PR DESCRIPTION
This change makes it possible to pass a `RepeatMode` when starting to repeat a closure with a given time interval. This is very useful for situations when you want to repeat something only a few times without having to manually manage a token for it.