### PR TITLE
Collision detection: Activate lazily, make more thorough & remove 'any' events

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -69,9 +69,11 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
 
     internal let layer = Layer()
     internal lazy var actorsInContact = Set<Actor>()
+    internal lazy var blocksInContact = Set<Block>()
     internal lazy var gridTiles = Set<Grid.Tile>()
     internal private(set) var isClickable = false
     internal var isWithinScene = false
+    internal var isCollisionDetectionActive = false
 
     private let pluginManager = PluginManager()
     private lazy var actionManager = ActionManager(object: self)

--- a/Sources/Core/API/ActorEventCollection.swift
+++ b/Sources/Core/API/ActorEventCollection.swift
@@ -16,10 +16,6 @@ public final class ActorEventCollection: EventCollection<Actor> {
     public private(set) lazy var rectChanged = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor's velocity changed
     public private(set) lazy var velocityChanged = Event<Actor, Void>(object: self.object)
-    /// Event triggered when the actor collided with any other actor
-    public private(set) lazy var collidedWithAnyActor = Event<Actor, Actor>(object: self.object)
-    /// Event triggered when the actor collided with any block
-    public private(set) lazy var collidedWithAnyBlock = Event<Actor, Block>(object: self.object)
     /// Event triggered when actor entered its scene
     public private(set) lazy var enteredScene = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor exited its scene
@@ -29,16 +25,20 @@ public final class ActorEventCollection: EventCollection<Actor> {
 
     /// Event triggered when the actor collided with another actor
     public func collided(with actor: Actor) -> Event<Actor, Actor> {
+        object?.isCollisionDetectionActive = true
+        actor.isCollisionDetectionActive = true
         return makeEvent(withSubject: actor)
     }
 
     /// Event triggered when the actor collided with an actor in a given group
     public func collided(withActorInGroup group: Group) -> Event<Actor, Actor> {
+        object?.isCollisionDetectionActive = true
         return makeEvent(withSubjectIdentifier: group.identifier)
     }
 
     /// Event triggered when the actor collided with a block in a given group
     public func collided(withBlockInGroup group: Group) -> Event<Actor, Block> {
+        object?.isCollisionDetectionActive = true
         return makeEvent(withSubjectIdentifier: group.identifier)
     }
 

--- a/Sources/Core/API/Block.swift
+++ b/Sources/Core/API/Block.swift
@@ -35,6 +35,7 @@ public final class Block: SceneObject, InstanceHashable, ActionPerformer, ZIndex
     public var group: Group?
 
     internal let layer = Layer()
+    internal lazy var actorsInContact = Set<Actor>()
     internal lazy var gridTiles = Set<Grid.Tile>()
 
     private let content: Content

--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -270,7 +270,10 @@ internal final class Grid {
         }
     }
 
-    private func detectCollision(between actor: Actor, and block: Block, blockGroup: Group, mode: CollisionDetectionMode) {
+    private func detectCollision(between actor: Actor,
+                                 and block: Block,
+                                 blockGroup: Group,
+                                 mode: CollisionDetectionMode) {
         guard actor.rectForCollisionDetection.intersects(block.rect) else {
             return
         }

--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -31,6 +31,10 @@ internal final class Grid {
             actorInContact.actorsInContact.remove(actor)
         }
 
+        for blockInContact in actor.blocksInContact {
+            blockInContact.actorsInContact.remove(actor)
+        }
+
         for tile in actor.gridTiles {
             tile.actors.remove(actor)
         }
@@ -51,6 +55,10 @@ internal final class Grid {
     func remove(_ block: Block) {
         guard blocks.remove(block) != nil else {
             return
+        }
+
+        for actorInContact in block.actorsInContact {
+            actorInContact.blocksInContact.remove(block)
         }
 
         for tile in block.gridTiles {
@@ -120,6 +128,14 @@ internal final class Grid {
 
                 actor.actorsInContact.remove(otherActor)
             }
+
+            for block in tile.blocks {
+                guard block.actorsInContact.remove(actor) != nil else {
+                    continue
+                }
+
+                actor.blocksInContact.remove(block)
+            }
         }
     }
 
@@ -134,10 +150,20 @@ internal final class Grid {
 
             tile.blocks.insert(block)
             block.gridTiles.insert(tile)
+
+            performCollisionDetection(for: block, in: tile)
         }
 
         for tile in tilesExited {
             tile.blocks.remove(block)
+
+            for actor in tile.actors {
+                guard actor.blocksInContact.remove(block) != nil else {
+                    continue
+                }
+
+                block.actorsInContact.remove(actor)
+            }
         }
     }
 
@@ -172,12 +198,62 @@ internal final class Grid {
     }
 
     private func performCollisionDetection(for actor: Actor, in tile: Tile) {
-        guard shouldPerformCollisionDetection(for: actor) else {
+        guard let mode = resolveCollisionDetectionMode(for: actor) else {
             return
         }
 
-        for otherActor in tile.actors {
-            guard shouldPerformCollisionDetection(for: otherActor) else {
+        switch mode {
+        case .full:
+            detectCollisions(between: actor, and: tile.actors)
+        case .constraintsOnly:
+            break
+        }
+
+        for block in tile.blocks {
+            guard let blockGroup = block.group else {
+                continue
+            }
+
+            detectCollision(between: actor, and: block, blockGroup: blockGroup, mode: mode)
+        }
+    }
+
+    private func performCollisionDetection(for block: Block, in tile: Tile) {
+        guard let group = block.group else {
+            return
+        }
+
+        for actor in tile.actors {
+            guard let mode = resolveCollisionDetectionMode(for: actor) else {
+                continue
+            }
+
+            detectCollision(between: actor, and: block, blockGroup: group, mode: mode)
+        }
+    }
+
+    private func resolveCollisionDetectionMode(for actor: Actor) -> CollisionDetectionMode? {
+        if actor.group != nil {
+            return .full
+        }
+
+        if actor.isCollisionDetectionEnabled && actor.isCollisionDetectionActive {
+            return .full
+        }
+
+        if !actor.constraints.isEmpty {
+            return .constraintsOnly
+        }
+
+        return nil
+    }
+
+    private func detectCollisions(between actor: Actor, and otherActors: Set<Actor>) {
+        for otherActor in otherActors {
+            switch resolveCollisionDetectionMode(for: otherActor) {
+            case .full?:
+                break
+            case nil, .constraintsOnly?:
                 continue
             }
 
@@ -189,46 +265,44 @@ internal final class Grid {
                 continue
             }
 
-            handleCollisionBetween(actor, and: otherActor)
-            handleCollisionBetween(otherActor, and: actor)
+            handleCollision(between: actor, and: otherActor)
+            handleCollision(between: otherActor, and: actor)
+        }
+    }
+
+    private func detectCollision(between actor: Actor, and block: Block, blockGroup: Group, mode: CollisionDetectionMode) {
+        guard actor.rectForCollisionDetection.intersects(block.rect) else {
+            return
         }
 
-        for block in tile.blocks {
-            guard actor.rectForCollisionDetection.intersects(block.rect) else {
-                continue
+        switch mode {
+        case .full:
+            guard !actor.blocksInContact.contains(block) else {
+                break
             }
 
-            handleCollisionBetween(actor, and: block)
+            actor.blocksInContact.insert(block)
+            block.actorsInContact.insert(actor)
+            actor.events.collided(withBlockInGroup: blockGroup).trigger(with: block)
+        case .constraintsOnly:
+            break
+        }
 
-            if let group = block.group {
-                if actor.constraints.contains(.neverOverlapBlockInGroup(group)) {
-                    move(actor, awayFrom: block)
-                }
+        if let group = block.group {
+            if actor.constraints.contains(.neverOverlapBlockInGroup(group)) {
+                move(actor, awayFrom: block)
             }
         }
     }
 
-    private func shouldPerformCollisionDetection(for actor: Actor) -> Bool {
-        return actor.isCollisionDetectionEnabled && actor.scene != nil
-    }
-
-    private func handleCollisionBetween(_ actorA: Actor, and actorB: Actor) {
+    private func handleCollision(between actorA: Actor, and actorB: Actor) {
         actorA.events.collided(with: actorB).trigger(with: actorB)
-        actorA.events.collidedWithAnyActor.trigger(with: actorB)
 
         if let group = actorB.group {
             actorA.events.collided(withActorInGroup: group).trigger(with: actorB)
         }
 
         actorA.actorsInContact.insert(actorB)
-    }
-
-    private func handleCollisionBetween(_ actor: Actor, and block: Block) {
-        actor.events.collidedWithAnyBlock.trigger(with: block)
-
-        if let group = block.group {
-            actor.events.collided(withBlockInGroup: group).trigger(with: block)
-        }
     }
 
     private func move(_ actor: Actor, awayFrom block: Block) {
@@ -274,6 +348,11 @@ private extension Grid {
         let x: Int
         let y: Int
         var hashValue: Int { return x ^ y }
+    }
+
+    enum CollisionDetectionMode {
+        case full
+        case constraintsOnly
     }
 }
 

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -393,6 +393,62 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(numberOfCollisions, 5)
     }
 
+    func testObservingCollisionWithActorInGroup() {
+        actor.size = Size(width: 100, height: 100)
+        actor.position = Point(x: 300, y: 300)
+
+        let group = Group.name("ActorGroup")
+
+        let otherActor = Actor(size: Size(width: 100, height: 100))
+        otherActor.group = group
+        game.scene.add(otherActor)
+
+        var numberOfCollisions = 0
+
+        actor.events.collided(withActorInGroup: group).observe {
+            numberOfCollisions += 1
+        }
+
+        XCTAssertEqual(numberOfCollisions, 0)
+
+        // Move the actor to collide with the other actor
+        actor.position = otherActor.position
+        XCTAssertEqual(numberOfCollisions, 1)
+
+        // Then move the other actor away, then back, which should also trigger a collision
+        otherActor.position = Point(x: 300, y: 300)
+        otherActor.position = actor.position
+        XCTAssertEqual(numberOfCollisions, 2)
+    }
+
+    func testObservingCollisionWithBlockInGroup() {
+        actor.size = Size(width: 100, height: 100)
+        actor.position = Point(x: 300, y: 300)
+
+        let group = Group.name("BlockGroup")
+
+        let block = Block(size: Size(width: 100, height: 100), spriteSheetName: "Block")
+        block.group = group
+        game.scene.add(block)
+
+        var numberOfCollisions = 0
+
+        actor.events.collided(withBlockInGroup: group).observe {
+            numberOfCollisions += 1
+        }
+
+        XCTAssertEqual(numberOfCollisions, 0)
+
+        // Move the actor to collide with the block
+        actor.position = block.position
+        XCTAssertEqual(numberOfCollisions, 1)
+
+        // Then move the other actor away, then back, which should also trigger a collision
+        block.position = Point(x: 300, y: 300)
+        block.position = actor.position
+        XCTAssertEqual(numberOfCollisions, 2)
+    }
+
     func testAssigningZIndex() {
         XCTAssertEqual(actor.zIndex, 0)
 


### PR DESCRIPTION
This change introduces several optimizations in how collision detection is performed for both actors and blocks, in order to avoid duplicate or unnecessary operations.

- Activate an object’s collision detection lazily, whenever a collision event is first accessed.
- Remove collision events that target any actor or any block. These make it hard to perform optimizations, and are very unlikely to be used in any real-life game development.
- Keep track of whenever a block and actor is in contact, to avoid handling duplicate collisions.
- Don’t perform collision detection unless someone’s interested in it, and in case we only need to do collision detection to evaluate constraints, there’s now an optimization path for that.

With this change, adding 100 objects on the same point in a scene is now over 20 times faster! 🚀