### PR TITLE
Timeline: Improve performance by reducing needs for mutations

### DIFF
--- a/Sources/Core/API/Timeline.swift
+++ b/Sources/Core/API/Timeline.swift
@@ -82,14 +82,17 @@ public final class Timeline: Activatable {
         lastUpdateTime = currentTime
         let currentTime = currentTime - pauseInterval
 
-        for updatable in immediateUpdatables.removeAll() {
+        for updatable in immediateUpdatables {
             let outcome = updatable.update(currentTime: currentTime)
 
             switch outcome {
             case .continueAfter(let delay):
-                schedule(updatable, delay: delay)
+                if delay > 0 {
+                    immediateUpdatables.remove(updatable)
+                    schedule(updatable, delay: delay)
+                }
             case .finished:
-                break
+                immediateUpdatables.remove(updatable)
             }
         }
 
@@ -164,8 +167,10 @@ private extension Timeline {
         }
 
         func update(in timeline: Timeline, currentTime: TimeInterval) -> NodeUpdateOutcome {
-            if currentTime >= time {
-                for updatable in updatables.removeAll() {
+            let deadlineReached = currentTime >= time
+
+            if deadlineReached {
+                for updatable in updatables {
                     let outcome = updatable.update(currentTime: currentTime)
 
                     switch outcome {
@@ -201,7 +206,7 @@ private extension Timeline {
                 }
             }
 
-            return updatables.isEmpty ? .discard : .keep
+            return deadlineReached ? .discard : .keep
         }
     }
 

--- a/Sources/Core/Internal/UpdatableCollection.swift
+++ b/Sources/Core/Internal/UpdatableCollection.swift
@@ -7,25 +7,76 @@
 import Foundation
 
 internal struct UpdatableCollection {
-    var isEmpty: Bool { return objects.isEmpty }
+    var isEmpty: Bool { return firstNode == nil }
 
-    private var identifiers = Set<ObjectIdentifier>()
-    private var objects = [UpdatableWrapper]()
+    private var firstNode: Node?
+    private var lastNode: Node?
+    private var allNodes = [ObjectIdentifier : Node]()
 
     mutating func insert(_ object: UpdatableWrapper) {
         let identifier = ObjectIdentifier(object)
 
-        guard identifiers.insert(identifier).inserted else {
+        guard allNodes[identifier] == nil else {
             return
         }
 
-        objects.append(object)
+        let node = Node(object: object)
+        allNodes[identifier] = node
+
+        if let parentNode = lastNode {
+            parentNode.next = node
+            node.previous = parentNode
+            lastNode = node
+        } else {
+            firstNode = node
+            lastNode = node
+        }
     }
 
-    mutating func removeAll() -> [UpdatableWrapper] {
-        let allObjects = objects
-        objects = []
-        identifiers = []
-        return allObjects
+    mutating func remove(_ object: UpdatableWrapper) {
+        let identifier = ObjectIdentifier(object)
+
+        guard let node = allNodes.removeValue(forKey: identifier) else {
+            return
+        }
+
+        node.next?.previous = node.previous
+        node.previous?.next = node.next
+
+        if node === firstNode {
+            firstNode = node.next
+        }
+
+        if node === lastNode {
+            lastNode = node.previous
+        }
+    }
+}
+
+extension UpdatableCollection: Sequence {
+    struct Iterator: IteratorProtocol {
+        fileprivate var node: Node?
+
+        mutating func next() -> UpdatableWrapper? {
+            let currentNode = node
+            node = currentNode?.next
+            return currentNode?.object
+        }
+    }
+
+    func makeIterator() -> Iterator {
+        return Iterator(node: firstNode)
+    }
+}
+
+private extension UpdatableCollection {
+    final class Node {
+        let object: UpdatableWrapper
+        weak var previous: Node?
+        var next: Node?
+
+        init(object: UpdatableWrapper) {
+            self.object = object
+        }
     }
 }

--- a/Tests/ImagineEngineTests/TimelineTests.swift
+++ b/Tests/ImagineEngineTests/TimelineTests.swift
@@ -120,4 +120,40 @@ final class TimelineTests: XCTestCase {
         game.update()
         XCTAssertEqual(runCount, 2)
     }
+
+    func testScheduledClosureNotRetained() {
+        var actor = Actor()
+        weak var weakActor = actor
+
+        game.scene.timeline.after(interval: 2) {
+            // Capture the actor as a strong reference
+            actor.backgroundColor = .red
+        }
+
+        game.timeTraveler.travel(by: 2)
+        game.update()
+
+        // The closure should now have been removed, and the actor shouldn't be retained
+        actor = Actor()
+        XCTAssertNil(weakActor)
+    }
+
+    func testRepeatedClosureNotRetained() {
+        var actor = Actor()
+        weak var weakActor = actor
+
+        game.scene.timeline.repeat(withInterval: 2, mode: .times(2)) {
+            // Capture the actor as a strong reference
+            actor.backgroundColor = .red
+        }
+
+        game.timeTraveler.travel(by: 2)
+        game.update()
+        game.timeTraveler.travel(by: 2)
+        game.update()
+
+        // The closure should now have been removed, and the actor shouldn't be retained
+        actor = Actor()
+        XCTAssertNil(weakActor)
+    }
 }


### PR DESCRIPTION
This patch makes `Timeline` handle large amounts of updates a lot better, by reducing the need for performing mutations on value types.

Currently, whenever a frame is rendered, `Timeline` removes all of its updatables from `UpdatableCollection`, updates them and then re-adds them to the collection. This gives us a lot of unncesseceray value mutations.

On top of that we were using `Set` and `Array` to store updatables, both by identity and by index. This required more memory than neccessary, and made mutations more expensive, since many times the underlying buffers needed to be copied, destroyed or re-created.

With this patch, we are now storing updatables using linked lists instead, which, in combination with a lightweight dictionary index gives us both quick inserts and deletions. We also don’t always remove all updatables, and instead insert and remove as needed.