### PR TITLE
Scene: Add events for when an actor is added or removed

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -111,12 +111,15 @@ open class Scene: Pluggable, Activatable {
         grid.add(actor, in: self)
         actor.addLayer(to: layer)
         game.map(actor.activate)
+
+        events.actorAdded.trigger(with: actor)
     }
 
     /// Remove an actor from the scene
     public func remove(_ actor: Actor) {
         deactivate(actor)
         grid.remove(actor)
+        events.actorRemoved.trigger(with: actor)
     }
 
     /// Get all actors which rects intersect a given point

--- a/Sources/Core/API/SceneEventCollection.swift
+++ b/Sources/Core/API/SceneEventCollection.swift
@@ -10,6 +10,10 @@ import Foundation
 public final class SceneEventCollection: EventCollection<Scene> {
     /// Event that gets triggered when the scene was clicked or tapped
     public private(set) lazy var clicked = makeClickedEvent()
+    /// Event that gets triggered when an actor was added to the scene
+    public private(set) lazy var actorAdded = Event<Scene, Actor>(object: object)
+    /// Event that gets triggered when an actor was removed from the scene
+    public private(set) lazy var actorRemoved = Event<Scene, Actor>(object: object)
     /// Event that gets triggered when its safe area insets changed
     public private(set) lazy var safeAreaInsetsChanged = Event<Scene, Void>(object: object)
 

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -17,15 +17,28 @@ final class SceneTests: XCTestCase {
     }
 
     func testAddingAndRemovingActor() {
+        var addedActor: Actor?
+        var removedActor: Actor?
+
+        game.scene.events.actorAdded.observe { _, actor in
+            addedActor = actor
+        }
+
+        game.scene.events.actorRemoved.observe { _, actor in
+            removedActor = actor
+        }
+
         let actor = Actor()
 
         game.scene.add(actor)
         XCTAssertEqual(game.scene.actors, [actor])
         assertSameInstance(game.scene, actor.scene)
+        assertSameInstance(addedActor, actor)
 
         actor.remove()
         XCTAssertEqual(game.scene.actors, [])
         XCTAssertNil(actor.scene)
+        assertSameInstance(removedActor, actor)
     }
 
     func testAddingAndRemovingMultipleActors() {


### PR DESCRIPTION
This change introduces two new events for `Scene`; `actorAdded` & `actorRemoved`. This enables observation of when an actor is added or removed from a scene.

Resolves https://github.com/JohnSundell/ImagineEngine/issues/68