### PR TITLE
Camera: add moved event to observe changes in position of camera

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		026CE1C41FC06B7E00A0998B /* CameraEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CE1C31FC06B7E00A0998B /* CameraEventCollection.swift */; };
+		026CE1C51FC06B7E00A0998B /* CameraEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CE1C31FC06B7E00A0998B /* CameraEventCollection.swift */; };
+		026CE1C61FC06B7E00A0998B /* CameraEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CE1C31FC06B7E00A0998B /* CameraEventCollection.swift */; };
 		5204849D1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
 		5204849E1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
 		520484A21FA357070011D372 /* ClickGestureRecognizer-macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */; };
@@ -325,6 +328,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		026CE1C31FC06B7E00A0998B /* CameraEventCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraEventCollection.swift; sourceTree = "<group>"; };
 		5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickGestureRecognizerMock.swift; sourceTree = "<group>"; };
 		5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClickGestureRecognizer-macOS.swift"; sourceTree = "<group>"; };
 		522CD6281F8D4512008DB43D /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
@@ -508,6 +512,7 @@
 				522CD62F1F8D4512008DB43D /* Block.swift */,
 				522CD6301F8D4512008DB43D /* BlockTextureCollection.swift */,
 				522CD6311F8D4512008DB43D /* Camera.swift */,
+				026CE1C31FC06B7E00A0998B /* CameraEventCollection.swift */,
 				522CD6321F8D4512008DB43D /* CancellationToken.swift */,
 				522CD6331F8D4512008DB43D /* ClosureAction.swift */,
 				522CD6341F8D4512008DB43D /* Constraint.swift */,
@@ -1045,6 +1050,7 @@
 				5253C7A01FA4D56C00D304B5 /* ClickPlugin.swift in Sources */,
 				5253C7C01FA4D57200D304B5 /* Event.swift in Sources */,
 				5253C7A21FA4D56C00D304B5 /* DisplayLinkProtocol.swift in Sources */,
+				026CE1C61FC06B7E00A0998B /* CameraEventCollection.swift in Sources */,
 				5253C7B01FA4D56C00D304B5 /* UpdatableWrapper.swift in Sources */,
 				5253C7A71FA4D56C00D304B5 /* LoadedTexture.swift in Sources */,
 				52B806601FB373BC0042FBA7 /* ZIndexed.swift in Sources */,
@@ -1152,6 +1158,7 @@
 				522CD6841F8D451D008DB43D /* RepeatAction.swift in Sources */,
 				522CD6931F8D4521008DB43D /* ClosureUpdatable.swift in Sources */,
 				522CD69A1F8D4521008DB43D /* LoadedTexture.swift in Sources */,
+				026CE1C41FC06B7E00A0998B /* CameraEventCollection.swift in Sources */,
 				522CD6701F8D451D008DB43D /* Block.swift in Sources */,
 				522CD6A11F8D4521008DB43D /* Updatable.swift in Sources */,
 				52B8065E1FB373BC0042FBA7 /* ZIndexed.swift in Sources */,
@@ -1269,6 +1276,7 @@
 				C800CE311FA782EA008EE08D /* TextureFormat.swift in Sources */,
 				DD21B73A1F92E8240034A7CE /* Image-macOS.swift in Sources */,
 				DD21B7051F92E75A0034A7CE /* Group.swift in Sources */,
+				026CE1C51FC06B7E00A0998B /* CameraEventCollection.swift in Sources */,
 				DD21B7441F92EB1A0034A7CE /* DisplayLink-macOS.swift in Sources */,
 				DD21B73D1F92E8CB0034A7CE /* Screen-macOS.swift in Sources */,
 				5253C7DE1FA4D7E400D304B5 /* Font+Default.swift in Sources */,

--- a/Sources/Core/API/Camera.swift
+++ b/Sources/Core/API/Camera.swift
@@ -20,6 +20,8 @@ public final class Camera: ActionPerformer, Pluggable, Movable, Activatable {
     public internal(set) var size = Size() { didSet { sizeDidChange(from: oldValue) }}
     /// The current rectangle of the camera's viewport.
     public private(set) var rect = Rect()
+    /// A collection of events that can be used to observe the camera.
+    public private(set) lazy var events = CameraEventCollection(object: self)
     /// Whether the camera is constrained to the scene or can move outside of it (default = false)
     public var constrainedToScene = false { didSet { update() } }
 
@@ -80,6 +82,7 @@ public final class Camera: ActionPerformer, Pluggable, Movable, Activatable {
     private func positionDidChange(from oldValue: Point) {
         if position != oldValue {
             update()
+            events.moved.trigger(with: (oldValue, position))
         }
     }
 

--- a/Sources/Core/API/CameraEventCollection.swift
+++ b/Sources/Core/API/CameraEventCollection.swift
@@ -1,0 +1,13 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+
+/// Events that can be used to observe a camera
+public final class CameraEventCollection: EventCollection<Camera> {
+    /// Event triggered when the camera was moved
+    public private(set) lazy var moved = Event<Camera, (old: Point, new: Point)>(object: self.object)
+}

--- a/Tests/ImagineEngineTests/CameraTests.swift
+++ b/Tests/ImagineEngineTests/CameraTests.swift
@@ -75,6 +75,31 @@ final class CameraTests: XCTestCase {
         XCTAssertEqual(scene.camera.position, Point(x: -2000, y: -1000))
     }
 
+    func testObservingMove() {
+        let scene = Scene(size: Size(width: 500, height: 500))
+
+        var noValueTriggerCount = 0
+        scene.camera.events.moved.observe { noValueTriggerCount += 1 }
+
+        var cameraPositions = [Point]()
+        var oldPositions = [Point]()
+        var newPositions = [Point]()
+
+        scene.camera.events.moved.observe { actor, positions in
+            cameraPositions.append(actor.position)
+            oldPositions.append(positions.old)
+            newPositions.append(positions.new)
+        }
+
+        scene.camera.position.x += 100
+        scene.camera.position.y += 50
+
+        XCTAssertEqual(noValueTriggerCount, 2)
+        XCTAssertEqual(cameraPositions, [Point(x: 350, y: 250), Point(x: 350, y: 300)])
+        XCTAssertEqual(oldPositions, [Point(x: 250, y: 250), Point(x: 350, y: 250)])
+        XCTAssertEqual(newPositions, [Point(x: 350, y: 250), Point(x: 350, y: 300)])
+    }
+
     func testAddingAndRemovingPlugin() {
         let plugin = PluginMock<Camera>()
 


### PR DESCRIPTION
This PR introduces  new `CameraEventsCollection` along with `moved` event to observe changes in camera`s position. 

Linked issue #86 