### PR TITLE
Asteroid blaster tutorial: Update for removed any block event

### DIFF
--- a/Documentation/Tutorials/1-AsteroidBlaster/FinalCode.swift
+++ b/Documentation/Tutorials/1-AsteroidBlaster/FinalCode.swift
@@ -45,7 +45,10 @@ class AsteroidBlasterScene: Scene {
 
             asteroid.velocity.dy = 100
 
-            asteroid.events.collidedWithAnyBlock.observe { asteroid in
+            let groundGroup = Group.name("Ground")
+            ground.group = groundGroup
+
+            asteroid.events.collided(withBlockInGroup: groundGroup).observe { asteroid in
                 asteroid.explode()
             }
 

--- a/Documentation/Tutorials/1-AsteroidBlaster/FinalCode.swift
+++ b/Documentation/Tutorials/1-AsteroidBlaster/FinalCode.swift
@@ -12,13 +12,15 @@ class AsteroidBlasterScene: Scene {
     override func setup() {
         backgroundColor = Color(red: 0, green: 0, blue: 0.3, alpha: 1)
 
+        let housesGroup = Group.name("Houses")
+        let groundGroup = Group.name("Ground")
+
         let groundSize = Size(width: size.width, height: 100)
         let ground = Block(size: groundSize, textureCollectionName: "Ground")
         ground.position.x = center.x
         ground.position.y = size.height - groundSize.height / 2
+        ground.group = groundGroup
         add(ground)
-
-        let housesGroup = Group.name("Houses")
 
         for x in stride(from: center.x - 100, to: center.x + 150, by: 50) {
             let house = Actor()
@@ -44,9 +46,6 @@ class AsteroidBlasterScene: Scene {
             asteroid.position.x = asteroid.size.width / 2 + randomPosition
 
             asteroid.velocity.dy = 100
-
-            let groundGroup = Group.name("Ground")
-            ground.group = groundGroup
 
             asteroid.events.collided(withBlockInGroup: groundGroup).observe { asteroid in
                 asteroid.explode()

--- a/Documentation/Tutorials/1-AsteroidBlaster/README.md
+++ b/Documentation/Tutorials/1-AsteroidBlaster/README.md
@@ -155,10 +155,13 @@ You'll now start seeing asteroids falling from the sky 🌠:
 
 Right now, each asteroid will keep falling indefinitely, even if it hits the ground or a house. To fix that, let's add some collision detection. Collisions are a core part of most games, but doing collision detection in a performant and nice way can sometimes be very tricky. Thankfully, Imagine Engine provides a super easy to use API for observing many types of collisions.
 
-For our game, we want to add two collisions. The first, is when an asteroid collides with our ground block, at which point we want to destroy and remove the asteroid. To handle such a collision, let's observe the `collidedWithAnyBlock` event on each asteroid, like this:
+For our game, we want to add two collisions. The first, is when an asteroid collides with our ground block, at which point we want to destroy and remove the asteroid. To handle such a collision, let's associate our ground block with a group called `Ground`, and then observe the `collided(withBlockInGroup:)` event on each asteroid - like this:
 
 ```swift
-asteroid.events.collidedWithAnyBlock.observe { asteroid in
+let groundGroup = Group.name("Ground")
+ground.group = groundGroup
+
+asteroid.events.collided(withBlockInGroup: groundGroup).observe { asteroid in
     // An asteroid collided with our ground block
 }
 ```


### PR DESCRIPTION
The asteroid blaster tutorial was using the now deleted `collidedWithAnyBlock` event, so this patch updates it to now use `collided(withBlockInGroup:)` instead.