### PR TITLE
Actor: Added rotated event

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -41,7 +41,7 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
     /// The rectangle the actor currently occupies within its scene.
     public private(set) var rect = Rect() { didSet { rectDidChange() } }
     /// The rotation of the actor along the z axis.
-    public var rotation = Metric() { didSet { layer.rotation = rotation } }
+    public var rotation = Metric() { didSet { rotationDidChange(from: oldValue) } }
     /// The scale the actor gets rendered at. Affects collision detection unless a hitboxSize is set.
     public var scale: Metric = 1 { didSet { scaleDidChange(from: oldValue) } }
     /// The velocity of the actor. Used for continous directional movement.
@@ -210,6 +210,16 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
 
         events.resized.trigger()
         events.rectChanged.trigger()
+    }
+
+    private func rotationDidChange(from oldValue: Metric) {
+        guard rotation != oldValue else {
+            return
+        }
+
+        layer.rotation = rotation
+
+        events.rotated.trigger()
     }
 
     private func rectDidChange() {

--- a/Sources/Core/API/ActorEventCollection.swift
+++ b/Sources/Core/API/ActorEventCollection.swift
@@ -12,6 +12,8 @@ public final class ActorEventCollection: EventCollection<Actor> {
     public private(set) lazy var moved = Event<Actor, (old: Point, new: Point)>(object: self.object)
     /// Event triggered when the actor was resized
     public private(set) lazy var resized = Event<Actor, Void>(object: self.object)
+    /// Event triggered when the actor was rotated
+    public private(set) lazy var rotated = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor's rectangle changed (either by position or size)
     public private(set) lazy var rectChanged = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor's velocity changed

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -325,6 +325,20 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(velocities, [Vector(dx: 100, dy: 0), Vector(dx: 100, dy: 50)])
     }
 
+    func testObservingRotationChange() {
+        var noValueTriggerCount = 0
+        actor.events.rotated.observe { noValueTriggerCount += 1 }
+
+        actor.rotation = 1
+        actor.rotation = 2
+
+        // Setting rotation to same value should not generate event
+        actor.rotation = 2
+
+        XCTAssertEqual(noValueTriggerCount, 2)
+        XCTAssertEqual(actor.layer.rotation, 2, accuracy: 0.001)
+    }
+
     func testObservingCollisionsWithOtherActor() {
         let otherActor = Actor(size: Size(width: 100, height: 100))
         game.scene.add(otherActor)

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -326,8 +326,8 @@ final class ActorTests: XCTestCase {
     }
 
     func testObservingRotationChange() {
-        var noValueTriggerCount = 0
-        actor.events.rotated.observe { noValueTriggerCount += 1 }
+        var triggerCount = 0
+        actor.events.rotated.observe { triggerCount += 1 }
 
         actor.rotation = 1
         actor.rotation = 2
@@ -335,7 +335,7 @@ final class ActorTests: XCTestCase {
         // Setting rotation to same value should not generate event
         actor.rotation = 2
 
-        XCTAssertEqual(noValueTriggerCount, 2)
+        XCTAssertEqual(triggerCount, 2)
         XCTAssertEqual(actor.layer.rotation, 2, accuracy: 0.001)
     }
 


### PR DESCRIPTION
Event for when rotation changes is useful for example when you want the rotation of two actors to be synchronized.