### PR TITLE
Grid: Fix bug causing actors in groups always participating in collisions

### DIFF
--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -233,12 +233,10 @@ internal final class Grid {
     }
 
     private func resolveCollisionDetectionMode(for actor: Actor) -> CollisionDetectionMode? {
-        if actor.group != nil {
-            return .full
-        }
-
-        if actor.isCollisionDetectionEnabled && actor.isCollisionDetectionActive {
-            return .full
+        if actor.isCollisionDetectionEnabled {
+            if actor.isCollisionDetectionActive || actor.group != nil {
+                return .full
+            }
         }
 
         if !actor.constraints.isEmpty {

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -482,6 +482,39 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(numberOfCollisions, 1)
     }
 
+    func testDisablingCollisionDetection() {
+        actor.size = Size(width: 100, height: 100)
+        actor.position = Point(x: 300, y: 300)
+
+        let otherActor = Actor(size: Size(width: 100, height: 100))
+        game.scene.add(otherActor)
+
+        var numberOfCollisions = 0
+
+        actor.events.collided(with: otherActor).observe {
+            numberOfCollisions += 1
+        }
+
+        otherActor.isCollisionDetectionEnabled = false
+        otherActor.position = actor.position
+        XCTAssertEqual(numberOfCollisions, 0)
+
+        // Regardless of which actor has collision detection disabled
+        // no collision should occur
+        otherActor.position = .zero
+        otherActor.isCollisionDetectionEnabled = true
+        actor.isCollisionDetectionEnabled = false
+        otherActor.position = actor.position
+        XCTAssertEqual(numberOfCollisions, 0)
+
+        // Make sure collision detection setting is still respected even
+        // an actor is assigned to a group
+        otherActor.position = .zero
+        actor.group = Group.number(1)
+        otherActor.position = actor.position
+        XCTAssertEqual(numberOfCollisions, 0)
+    }
+
     func testObservingCollisionWithBlockInGroup() {
         actor.size = Size(width: 100, height: 100)
         actor.position = Point(x: 300, y: 300)


### PR DESCRIPTION
This patch fixes a bug that would cause an actor that belongs to a group to always participate in collisions, even if collision detection had been disabled.