### PR TITLE
Animation: Support animating with JPG textures

### DIFF
--- a/Sources/Core/API/Animation.swift
+++ b/Sources/Core/API/Animation.swift
@@ -48,8 +48,12 @@ public extension Animation {
          frameIndexSeparator: String = "/",
          repeatMode: RepeatMode = .forever,
          autoResize: Bool = true,
-         ignoreTextureNamePrefix: Bool = false) {
-        self.content = .frames(withBaseName: name, indexSeparator: frameIndexSeparator, count: frameCount)
+         ignoreTextureNamePrefix: Bool = false,
+         textureFormat: TextureFormat = .png) {
+        self.content = .frames(withBaseName: name,
+                               indexSeparator: frameIndexSeparator,
+                               format: textureFormat,
+                               count: frameCount)
         self.frameDuration = frameDuration
         self.repeatMode = repeatMode
         self.autoResize = autoResize
@@ -185,8 +189,13 @@ private extension Animation {
 }
 
 private extension Animation.Content {
-    static func frames(withBaseName name: String, indexSeparator: String, count: Int) -> Animation.Content {
-        let frames = (0..<count).map { Texture(name: "\(name)\(indexSeparator)\($0)") }
+    static func frames(withBaseName name: String,
+                       indexSeparator: String,
+                       format: TextureFormat,
+                       count: Int) -> Animation.Content {
+        let frames = (0..<count).map {
+            Texture(name: "\(name)\(indexSeparator)\($0)", format: format)
+        }
         return .textures(frames)
     }
 

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -120,6 +120,41 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(game.textureImageLoader.imageNames, ["sheet.png", "sheet2.png"])
     }
 
+    func testDefaultAnimationTextureFormatIsPNG() {
+        var animation = Animation(
+            name: "Animation",
+            frameCount: 2,
+            frameDuration: 1
+        )
+
+        animation.textureScale = 1
+        actor.animation = animation
+
+        game.update()
+        game.timeTraveler.travel(by: 1)
+        game.update()
+
+        XCTAssertEqual(game.textureImageLoader.imageNames, ["Animation/0.png", "Animation/1.png"])
+    }
+
+    func testAnimatingWithJPGTextures() {
+        var animation = Animation(
+            name: "Animation",
+            frameCount: 2,
+            frameDuration: 1,
+            textureFormat: .jpg
+        )
+
+        animation.textureScale = 1
+        actor.animation = animation
+
+        game.update()
+        game.timeTraveler.travel(by: 1)
+        game.update()
+
+        XCTAssertEqual(game.textureImageLoader.imageNames, ["Animation/0.jpg", "Animation/1.jpg"])
+    }
+
     func testInitializingWithTextureName() {
         let actor = Actor(textureNamed: "SomeTexture", scale: 1)
         game.scene.add(actor)


### PR DESCRIPTION
This change makes it possible to form an animation for an Actor using JPG textures. This was already possible using explicit images or with a single texture, but it’s now also possible when referring to an animation by name.