### PR TITLE
CI: Migrate from Buddybuild to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: objective-c
+osx_image: xcode9.2
+script:
+    - bash CI.sh

--- a/CI.sh
+++ b/CI.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+function test_iOS {
+    xcodebuild clean test \
+        -project ImagineEngine.xcodeproj \
+        -scheme ImagineEngine-iOS \
+        -destination "platform=iOS Simulator,name=iPhone 8" \
+        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_REQUIRED=NO \
+        ONLY_ACTIVE_ARCH=NO
+}
+
 function test_macOS {
     xcodebuild clean test \
         -project ImagineEngine.xcodeproj \
@@ -24,10 +34,9 @@ function test_tvOS {
 set -eo pipefail
 
 # Run tests on macOS + tvOS
+test_iOS | xcpretty
 test_macOS | xcpretty
 test_tvOS | xcpretty
 
 # Run Danger
-chruby 2.3.1
-bundle install
 bundle exec danger


### PR DESCRIPTION
Since Buddybuild was just acquired by Apple they will stop supporting open source projects from the 1st of March. This change makes Imagine Engine start using Travis CI instead for its CI needs.