### PR TITLE
Label: Add support for observing clicks

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		5204849D1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
 		5204849E1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
 		520484A21FA357070011D372 /* ClickGestureRecognizer-macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */; };
+		521054261FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */; };
+		521054271FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */; };
+		521054281FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */; };
 		522CD6691F8D451D008DB43D /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6281F8D4512008DB43D /* Action.swift */; };
 		522CD66A1F8D451D008DB43D /* ActionPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD6291F8D4512008DB43D /* ActionPerformer.swift */; };
 		522CD66B1F8D451D008DB43D /* ActionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522CD62A1F8D4512008DB43D /* ActionToken.swift */; };
@@ -340,6 +343,7 @@
 		026CE1C31FC06B7E00A0998B /* CameraEventCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraEventCollection.swift; sourceTree = "<group>"; };
 		5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickGestureRecognizerMock.swift; sourceTree = "<group>"; };
 		5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClickGestureRecognizer-macOS.swift"; sourceTree = "<group>"; };
+		521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelEventCollection.swift; sourceTree = "<group>"; };
 		522CD6281F8D4512008DB43D /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		522CD6291F8D4512008DB43D /* ActionPerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionPerformer.swift; sourceTree = "<group>"; };
 		522CD62A1F8D4512008DB43D /* ActionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionToken.swift; sourceTree = "<group>"; };
@@ -537,6 +541,7 @@
 				522CD63B1F8D4512008DB43D /* Group.swift */,
 				522CD63C1F8D4512008DB43D /* InstanceHashable.swift */,
 				522CD63D1F8D4512008DB43D /* Label.swift */,
+				521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */,
 				522CD63E1F8D4512008DB43D /* MetricAction.swift */,
 				522CD63F1F8D4512008DB43D /* Mirroring.swift */,
 				522CD6401F8D4512008DB43D /* Movable.swift */,
@@ -1078,6 +1083,7 @@
 				5253C7A61FA4D56C00D304B5 /* Layer.swift in Sources */,
 				5253C7DD1FA4D66500D304B5 /* Font+Default.swift in Sources */,
 				5253C7D71FA4D57200D304B5 /* Texture.swift in Sources */,
+				521054281FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */,
 				5253C7CB1FA4D57200D304B5 /* Movable.swift in Sources */,
 				5253C7CD1FA4D57200D304B5 /* Plugin.swift in Sources */,
 				5253C7A31FA4D56C00D304B5 /* DisplayLink-iOS+tvOS.swift in Sources */,
@@ -1189,6 +1195,7 @@
 				528B21511FA382B300CE9967 /* UpdatableCollection.swift in Sources */,
 				522CD6971F8D4521008DB43D /* GameView.swift in Sources */,
 				522CD6911F8D4521008DB43D /* Activatable.swift in Sources */,
+				521054261FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */,
 				522CD67C1F8D451D008DB43D /* Group.swift in Sources */,
 				522CD67E1F8D451D008DB43D /* Label.swift in Sources */,
 				522CD6A21F8D4521008DB43D /* UpdatableWrapper.swift in Sources */,
@@ -1348,6 +1355,7 @@
 				DD21B72B1F92E75A0034A7CE /* Constraint.swift in Sources */,
 				DD21B72C1F92E75A0034A7CE /* Typealiases.swift in Sources */,
 				DD21B72D1F92E75A0034A7CE /* DisplayLinkProtocol.swift in Sources */,
+				521054271FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */,
 				528B21521FA382B300CE9967 /* UpdatableCollection.swift in Sources */,
 				DD21B72E1F92E75A0034A7CE /* ReplicatorLayer.swift in Sources */,
 				DD21B72F1F92E75A0034A7CE /* RepeatMode.swift in Sources */,

--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -73,7 +73,6 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
     internal lazy var actorsInContact = Set<Actor>()
     internal lazy var blocksInContact = Set<Block>()
     internal lazy var gridTiles = Set<Grid.Tile>()
-    internal private(set) var isClickable = false
     internal var isWithinScene = false
     internal var isCollisionDetectionActive = false
 
@@ -92,6 +91,32 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
 
     internal func addLayer(to superlayer: Layer) {
         superlayer.addSublayer(layer)
+    }
+
+    internal func add(to gridTile: Grid.Tile) {
+        gridTile.actors.insert(self)
+        gridTiles.insert(gridTile)
+    }
+
+    internal func remove(from gridTile: Grid.Tile) {
+        gridTile.actors.remove(self)
+        gridTiles.remove(gridTile)
+
+        for otherActor in gridTile.actors {
+            guard otherActor.actorsInContact.remove(self) != nil else {
+                continue
+            }
+
+            actorsInContact.remove(otherActor)
+        }
+
+        for block in gridTile.blocks {
+            guard block.actorsInContact.remove(self) != nil else {
+                continue
+            }
+
+            blocksInContact.remove(block)
+        }
     }
 
     // MARK: - ActionPerformer
@@ -159,22 +184,9 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
         }
     }
 
-    internal func makeClickable() {
-        guard !isClickable else {
-            return
-        }
-
-        isClickable = true
-        scene?.add(ClickPlugin())
-    }
-
     // MARK: - Private
 
     private func sceneDidChange() {
-        if isClickable {
-            scene?.add(ClickPlugin())
-        }
-
         renderFirstAnimationFrameIfNeeded()
     }
 

--- a/Sources/Core/API/ActorEventCollection.swift
+++ b/Sources/Core/API/ActorEventCollection.swift
@@ -23,7 +23,7 @@ public final class ActorEventCollection: EventCollection<Actor> {
     /// Event triggered when the actor exited its scene
     public private(set) lazy var leftScene = Event<Actor, Void>(object: self.object)
     /// Event triggered when the actor was clicked (on macOS) or tapped (on iOS/tvOS)
-    public private(set) lazy var clicked = makeClickedEvent()
+    public private(set) lazy var clicked = Event<Actor, Void>(object: object)
 
     /// Event triggered when the actor collided with another actor
     public func collided(with actor: Actor) -> Event<Actor, Actor> {
@@ -42,10 +42,5 @@ public final class ActorEventCollection: EventCollection<Actor> {
     public func collided(withBlockInGroup group: Group) -> Event<Actor, Block> {
         object?.isCollisionDetectionActive = true
         return makeEvent(withSubjectIdentifier: group.identifier)
-    }
-
-    private func makeClickedEvent() -> Event<Actor, Void> {
-        object?.makeClickable()
-        return Event<Actor, Void>(object: object)
     }
 }

--- a/Sources/Core/API/Block.swift
+++ b/Sources/Core/API/Block.swift
@@ -63,6 +63,24 @@ public final class Block: SceneObject, InstanceHashable, ActionPerformer, ZIndex
         superlayer.addSublayer(layer)
     }
 
+    internal func add(to gridTile: Grid.Tile) {
+        gridTile.blocks.insert(self)
+        gridTiles.insert(gridTile)
+    }
+
+    internal func remove(from gridTile: Grid.Tile) {
+        gridTile.blocks.remove(self)
+        gridTiles.remove(gridTile)
+
+        for actor in gridTile.actors {
+            guard actor.blocksInContact.remove(self) != nil else {
+                continue
+            }
+
+            actorsInContact.remove(actor)
+        }
+    }
+
     // MARK: - ActionPerformer
 
     @discardableResult public func perform(_ action: Action<Block>) -> ActionToken {

--- a/Sources/Core/API/LabelEventCollection.swift
+++ b/Sources/Core/API/LabelEventCollection.swift
@@ -1,0 +1,13 @@
+/**
+ *  Imagine Engine
+ *  Copyright (c) John Sundell 2017
+ *  See LICENSE file for license
+ */
+
+import Foundation
+
+/// Events that can be used to observe an label
+public final class LabelEventCollection: EventCollection<Label> {
+    /// Event triggered when the label was clicked (on macOS) or tapped (on iOS/tvOS)
+    public private(set) lazy var clicked = Event<Label, Void>(object: object)
+}

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -58,11 +58,13 @@ open class Scene: Pluggable, Activatable {
 
         camera = Camera(layer: layer, sceneSize: size)
         camera.position = Point(x: size.width / 2, y: size.height / 2)
-
         layer.isOpaque = true
+
         sizeDidChange()
         backgroundColorDidChange()
         setup()
+
+        add(ClickPlugin())
     }
 
     // MARK: - Override points
@@ -125,6 +127,11 @@ open class Scene: Pluggable, Activatable {
     /// Get all actors which rects intersect a given point
     public func actors(at point: Point) -> [Actor] {
         return grid.actors(at: point)
+    }
+
+    /// Get all the labels which rects intersect a given point
+    public func labels(at point: Point) -> [Label] {
+        return grid.labels(at: point)
     }
 
     // MARK: - Block API
@@ -245,6 +252,10 @@ open class Scene: Pluggable, Activatable {
 
     internal func blockRectDidChange(_ block: Block) {
         grid.blockRectDidChange(block)
+    }
+
+    internal func labelRectDidChange(_ label: Label) {
+        grid.labelRectDidChange(label)
     }
 
     // MARK: - Private

--- a/Sources/Core/Internal/ClickPlugin.swift
+++ b/Sources/Core/Internal/ClickPlugin.swift
@@ -54,9 +54,11 @@ internal final class ClickPlugin: Plugin {
         scene.events.clicked.trigger(with: point)
 
         scene.actors(at: point).forEach { actor in
-            if actor.isClickable {
-                actor.events.clicked.trigger()
-            }
+            actor.events.clicked.trigger()
+        }
+
+        scene.labels(at: point).forEach { label in
+            label.events.clicked.trigger()
         }
     }
 }

--- a/Sources/Core/Internal/SceneObject.swift
+++ b/Sources/Core/Internal/SceneObject.swift
@@ -8,5 +8,10 @@ import Foundation
 
 internal protocol SceneObject: Activatable {
     var scene: Scene? { get set }
+    var rect: Rect { get }
+    var gridTiles: Set<Grid.Tile> { get }
+
     func addLayer(to superlayer: Layer)
+    func add(to gridTile: Grid.Tile)
+    func remove(from gridTile: Grid.Tile)
 }

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -624,7 +624,6 @@ final class ActorTests: XCTestCase {
         XCTAssertEqual(actor.layer.shadowOffset.width, 10)
         XCTAssertEqual(actor.layer.shadowOffset.height, 7)
         XCTAssertEqual(actor.layer.shadowPath, path)
-
     }
 }
 

--- a/Tests/ImagineEngineTests/LabelTests.swift
+++ b/Tests/ImagineEngineTests/LabelTests.swift
@@ -80,4 +80,39 @@ final class LabelTests: XCTestCase {
         label.remove()
         XCTAssertFalse(plugin.isActive)
     }
+
+    func testObservingClicks() {
+        let labelA = Label(text: "Hello")
+        let labelB = Label(text: "World")
+        game.scene.add(labelA, labelB)
+
+        var labelAClickCount = 0
+        var labelBClickCount = 0
+        var clickedLabels = [Label]()
+
+        labelA.events.clicked.observe { label in
+            labelAClickCount += 1
+            clickedLabels.append(label)
+        }
+
+        labelB.events.clicked.observe { label in
+            labelBClickCount += 1
+            clickedLabels.append(label)
+        }
+
+        game.simulateClick(at: .zero)
+
+        XCTAssertEqual(labelAClickCount, 1)
+        XCTAssertEqual(labelBClickCount, 1)
+        XCTAssertEqual(clickedLabels, [labelB, labelA])
+
+        // Move label to make sure that the grid is updated
+        labelA.position = Point(x: 200, y: 300)
+        game.simulateClick(at: Point(x: 200, y: 300))
+
+        // Only labelA should have been clicked twice
+        XCTAssertEqual(labelAClickCount, 2)
+        XCTAssertEqual(labelBClickCount, 1)
+        XCTAssertEqual(clickedLabels, [labelB, labelA, labelA])
+    }
 }

--- a/Tests/ImagineEngineTests/Mocks/GameMock.swift
+++ b/Tests/ImagineEngineTests/Mocks/GameMock.swift
@@ -26,7 +26,7 @@ final class GameMock: Game {
                    displayLink: displayLink,
                    dateProvider: timeTraveler.generateDate)
 
-        scene.add(clickPlugin)
+        scene.add(clickPlugin, reuseExistingOfSameType: false)
 
         view.frame.size = scene.size
         containerView.addSubview(view)

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 import XCTest
-import ImagineEngine
+@testable import ImagineEngine
 
 final class SceneTests: XCTestCase {
     private var game: GameMock!
@@ -285,6 +285,12 @@ final class SceneTests: XCTestCase {
         game.scene.camera.position = Point(x: 1000, y: 1500)
         game.simulateClick(at: Point(x: 200, y: 350))
         XCTAssertEqual(clickedPoint, Point(x: 1050, y: 1550))
+    }
+
+    func testClickPluginAlwaysAdded() {
+        let scene = Scene(size: .zero)
+        let plugins = scene.plugins(ofType: ClickPlugin.self)
+        XCTAssertFalse(plugins.isEmpty)
     }
 
     func testSafeAreaInsets() {


### PR DESCRIPTION
This change makes it possible to observe clicks on labels. The opportunity to remove some code duplication between scene objects was also taken, so that each scene object is now responsible for its own grid tile management.

Also, since we now have two clickable objects - `Actor` and `Label`, click management has been simplified so that a scene always adds a `ClickPlugin` instead of doing it lazily. This should lead to some minor performance gains as checks can be removed whenever a click event is observed.