### PR TITLE
Scene: Fix actors/labels incorrectly returned for a given point

### DIFF
--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -89,7 +89,11 @@ internal final class Grid {
             return []
         }
 
-        let actors = tile.actors.filter { $0.isHitTestingEnabled }
+        let actors = tile.actors.filter { actor in
+            return actor.isHitTestingEnabled &&
+                   actor.rect.contains(point)
+        }
+
         return actors.sorted { $0.zIndex > $1.zIndex }
     }
 
@@ -100,7 +104,11 @@ internal final class Grid {
             return []
         }
 
-        return tile.labels.sorted { $0.zIndex > $1.zIndex }
+        let labels = tile.labels.filter { label in
+            return label.rect.contains(point)
+        }
+
+        return labels.sorted { $0.zIndex > $1.zIndex }
     }
 
     func actorRectDidChange(_ actor: Actor, in scene: Scene) {

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -319,4 +319,34 @@ final class SceneTests: XCTestCase {
         XCTAssertEqual(observationTriggerCount, 1)
         #endif
     }
+
+    func testActorsAtPoint() {
+        let actorA = Actor(size: Size(width: 100, height: 100))
+        let actorB = Actor(size: Size(width: 100, height: 100))
+        game.scene.add(actorA, actorB)
+
+        // Since both actors are at (0, 0), they should both be returned
+        // Actor B should be returned first, since it's on the top
+        XCTAssertEqual(game.scene.actors(at: .zero), [actorB, actorA])
+
+        // Move actor A slightly away, but still within the same grid tile
+        // to make sure it isn't invalidly returned
+        actorA.position.x = 60
+        XCTAssertEqual(game.scene.actors(at: .zero), [actorB])
+    }
+
+    func testLabelsAtPoint() {
+        let labelA = Label(text: "Hello")
+        let labelB = Label(text: "World")
+        game.scene.add(labelA, labelB)
+
+        // Since both labels are at (0, 0), they should both be returned
+        // Label B should be returned first, since it's on the top
+        XCTAssertEqual(game.scene.labels(at: .zero), [labelB, labelA])
+
+        // Move label A slightly away, but still within the same grid tile
+        // to make sure it isn't invalidly returned
+        labelA.position.x += labelA.size.width / 2 + 10
+        XCTAssertEqual(game.scene.labels(at: .zero), [labelB])
+    }
 }


### PR DESCRIPTION
This patch fixes a bug that could cause actors or labels to be incorrectly returned when asking for objects at a certain point. The problem was that all members of the grid tile in question would be returned. Now, we always check that an object’s rect contains the given point.