### PR TITLE
Scene: Add resized event

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -39,7 +39,7 @@ open class Scene: Pluggable, Activatable {
     /// The scene's texture manager, that keeps track of loaded textures.
     public let textureManager = TextureManager()
     /// The current size of the scene
-    public var size: Size { didSet { sizeDidChange() } }
+    public var size: Size { didSet { sizeDidChange(from: oldValue) } }
     /// The insets that make up the area that is safe to put content in, to avoid the notch
     /// & home indicator on iPhone X (can be observed using the safeAreaInsetsChanged event)
     public internal(set) var safeAreaInsets = EdgeInsets() { didSet { safeAreaInsetsDidChange(from: oldValue) } }
@@ -60,7 +60,7 @@ open class Scene: Pluggable, Activatable {
         camera.position = Point(x: size.width / 2, y: size.height / 2)
         layer.isOpaque = true
 
-        sizeDidChange()
+        sizeDidChange(from: .zero)
         backgroundColorDidChange()
         setup()
 
@@ -246,9 +246,14 @@ open class Scene: Pluggable, Activatable {
         timeline.isPaused = isPaused
     }
 
-    private func sizeDidChange() {
+    private func sizeDidChange(from oldValue: Size) {
+        guard size != oldValue else {
+            return
+        }
+
         layer.bounds.size = size
         camera.sceneSize = size
+        events.resized.trigger()
     }
 
     private func safeAreaInsetsDidChange(from oldValue: EdgeInsets) {

--- a/Sources/Core/API/SceneEventCollection.swift
+++ b/Sources/Core/API/SceneEventCollection.swift
@@ -9,16 +9,13 @@ import Foundation
 /// Events that can be used to observe a scene
 public final class SceneEventCollection: EventCollection<Scene> {
     /// Event that gets triggered when the scene was clicked or tapped
-    public private(set) lazy var clicked = makeClickedEvent()
+    public private(set) lazy var clicked = Event<Scene, Point>(object: object)
     /// Event that gets triggered when an actor was added to the scene
     public private(set) lazy var actorAdded = Event<Scene, Actor>(object: object)
     /// Event that gets triggered when an actor was removed from the scene
     public private(set) lazy var actorRemoved = Event<Scene, Actor>(object: object)
+    /// Event that gets triggered when the scene was resized
+    public private(set) lazy var resized = Event<Scene, Void>(object: object)
     /// Event that gets triggered when its safe area insets changed
     public private(set) lazy var safeAreaInsetsChanged = Event<Scene, Void>(object: object)
-
-    private func makeClickedEvent() -> Event<Scene, Point> {
-        object?.add(ClickPlugin())
-        return Event<Scene, Point>(object: object)
-    }
 }

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -349,4 +349,22 @@ final class SceneTests: XCTestCase {
         labelA.position.x += labelA.size.width / 2 + 10
         XCTAssertEqual(game.scene.labels(at: .zero), [labelB])
     }
+
+    func testObservingResize() {
+        var sizes = [Size]()
+
+        game.scene.events.resized.observe { scene in
+            sizes.append(scene.size)
+        }
+
+        game.scene.size = Size(width: 1000, height: 200)
+        XCTAssertEqual(sizes, [Size(width: 1000, height: 200)])
+
+        game.scene.size = .zero
+        XCTAssertEqual(sizes, [Size(width: 1000, height: 200), .zero])
+
+        // Setting the same size again should not retrigger the event
+        game.scene.size = .zero
+        XCTAssertEqual(sizes, [Size(width: 1000, height: 200), .zero])
+    }
 }


### PR DESCRIPTION
This new event will be triggered whenever a scene was resized. Also contains a small cleanup after always adding `ClickPlugin` to all scenes.