### PR TITLE
Refactor deactivation code to make it more predictable

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -154,12 +154,13 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
     internal func deactivate() {
         pluginManager.deactivate()
         actionManager.deactivate()
-        layer.removeFromSuperlayer()
     }
 
     /// Remove this actor from its scene
     public func remove() {
         scene?.remove(self)
+        scene = nil
+        layer.removeFromSuperlayer()
     }
 
     // MARK: - Internal

--- a/Sources/Core/API/Block.swift
+++ b/Sources/Core/API/Block.swift
@@ -55,6 +55,8 @@ public final class Block: SceneObject, InstanceHashable, ActionPerformer, ZIndex
     /// Remove this block from its scene
     public func remove() {
         scene?.remove(self)
+        scene = nil
+        layer.removeFromSuperlayer()
     }
 
     // MARK: - SceneObject
@@ -96,7 +98,6 @@ public final class Block: SceneObject, InstanceHashable, ActionPerformer, ZIndex
 
     internal func deactivate() {
         actionManager.deactivate()
-        layer.removeFromSuperlayer()
     }
 
     // MARK: - Private

--- a/Sources/Core/API/Label.swift
+++ b/Sources/Core/API/Label.swift
@@ -113,7 +113,6 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, Plugga
     internal func deactivate() {
         actionManager.deactivate()
         pluginManager.deactivate()
-        layer.removeFromSuperlayer()
     }
 
     // MARK: - Public
@@ -121,6 +120,8 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, Plugga
     /// Remove the label from its scene
     public func remove() {
         scene?.remove(self)
+        scene = nil
+        layer.removeFromSuperlayer()
     }
 
     // MARK: - Private

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -76,16 +76,15 @@ open class Scene: Pluggable, Activatable {
     /// Put your code that starts your game here.
     open func activate() {}
 
-    // MARK: - Scene API
+    // MARK: - API
 
     /// Reset the scene
     /// Calling this will remove all game objects from the scene, and
     /// reset it to its initial state. Once the reset has been completed,
     /// the `setup()` and `activate()` methods will be called.
     public func reset() {
-        actors.forEach(deactivate)
-        blocks.forEach(deactivate)
-        labels.forEach(deactivate)
+        grid.deactivate()
+        grid.removeAllObjects()
         pluginManager.deactivate()
 
         camera = Camera(scene: self, layer: layer)
@@ -103,8 +102,6 @@ open class Scene: Pluggable, Activatable {
         activate()
     }
 
-    // MARK: - Actor API
-
     /// Add an actor to the scene
     public func add(_ actor: Actor) {
         actor.scene = self
@@ -116,25 +113,6 @@ open class Scene: Pluggable, Activatable {
         events.actorAdded.trigger(with: actor)
     }
 
-    /// Remove an actor from the scene
-    public func remove(_ actor: Actor) {
-        deactivate(actor)
-        grid.remove(actor)
-        events.actorRemoved.trigger(with: actor)
-    }
-
-    /// Get all actors which rects intersect a given point
-    public func actors(at point: Point) -> [Actor] {
-        return grid.actors(at: point)
-    }
-
-    /// Get all the labels which rects intersect a given point
-    public func labels(at point: Point) -> [Label] {
-        return grid.labels(at: point)
-    }
-
-    // MARK: - Block API
-
     /// Add a block to the scene
     public func add(_ block: Block) {
         block.scene = self
@@ -143,14 +121,6 @@ open class Scene: Pluggable, Activatable {
         block.addLayer(to: layer)
         game.map(block.activate)
     }
-
-    /// Remove a block from the scene
-    public func remove(_ block: Block) {
-        deactivate(block)
-        grid.remove(block)
-    }
-
-    // MARK: - Label API
 
     /// Add a label to the scene
     public func add(_ label: Label) {
@@ -161,10 +131,14 @@ open class Scene: Pluggable, Activatable {
         game.map(label.activate)
     }
 
-    /// Remove a label from the scene
-    public func remove(_ label: Label) {
-        deactivate(label)
-        grid.remove(label)
+    /// Get all actors which rects intersect a given point
+    public func actors(at point: Point) -> [Actor] {
+        return grid.actors(at: point)
+    }
+
+    /// Get all the labels which rects intersect a given point
+    public func labels(at point: Point) -> [Label] {
+        return grid.labels(at: point)
     }
 
     // MARK: - Pluggable
@@ -231,6 +205,19 @@ open class Scene: Pluggable, Activatable {
         }
     }
 
+    internal func remove(_ actor: Actor) {
+        grid.remove(actor)
+        events.actorRemoved.trigger(with: actor)
+    }
+
+    internal func remove(_ block: Block) {
+        grid.remove(block)
+    }
+
+    internal func remove(_ label: Label) {
+        grid.remove(label)
+    }
+
     internal func blockRectDidChange(_ block: Block) {
         grid.blockRectDidChange(block)
     }
@@ -264,15 +251,6 @@ open class Scene: Pluggable, Activatable {
 
     private func backgroundColorDidChange() {
         layer.backgroundColor = backgroundColor.cgColor
-    }
-
-    private func deactivate(_ object: SceneObject) {
-        guard object.scene === self else {
-            return
-        }
-
-        object.scene = nil
-        object.deactivate()
     }
 }
 

--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -27,6 +27,8 @@ internal final class Grid: Activatable {
             return
         }
 
+        actor.deactivate()
+
         for actorInContact in actor.actorsInContact {
             actorInContact.actorsInContact.remove(actor)
         }
@@ -57,6 +59,8 @@ internal final class Grid: Activatable {
             return
         }
 
+        block.deactivate()
+
         for actorInContact in block.actorsInContact {
             actorInContact.blocksInContact.remove(block)
         }
@@ -78,7 +82,11 @@ internal final class Grid: Activatable {
     }
 
     func remove(_ label: Label) {
-        labels.remove(label)
+        guard labels.remove(label) != nil else {
+            return
+        }
+
+        label.deactivate()
         label.gridTiles.forEach(label.remove)
     }
 
@@ -134,6 +142,20 @@ internal final class Grid: Activatable {
 
     func labelRectDidChange(_ label: Label) {
         updateTiles(for: label, collisionDetector: nil)
+    }
+
+    func removeAllObjects() {
+        for actor in actors {
+            actor.remove()
+        }
+
+        for block in blocks {
+            block.remove()
+        }
+
+        for label in labels {
+            label.remove()
+        }
     }
 
     // MARK: - Activatable


### PR DESCRIPTION
This change refactors the way scene objects are deactivated and removed from a scene. Currently, the concepts of deactivation and removal are a bit entangled, so this change clears that up a bit.

- Deactivation: The object is no longer active in a scene, either because it was removed, or because the scene itself was deactivated.
- Removal: The object and its layer are removed from the scene.

To make this happen, `Grid` is now responsible for all deactivation, including when the scene is reset or when an object is removed.

To increase predictability, the only way to remove scene objects are now by calling `remove()` on the object itself, rather than being able to use an API on `Scene`.