### PR TITLE
Camera: Add ‘clicked’ event

### DIFF
--- a/Sources/Core/API/Camera.swift
+++ b/Sources/Core/API/Camera.swift
@@ -79,6 +79,12 @@ public final class Camera: ActionPerformer, Pluggable, Movable, Activatable {
         actionManager.deactivate()
     }
 
+    // MARK: - Internal
+
+    internal func handleClick(at point: Point) {
+        events.clicked.trigger(with: point)
+    }
+
     // MARK: - Private
 
     private func positionDidChange(from oldValue: Point) {

--- a/Sources/Core/API/CameraEventCollection.swift
+++ b/Sources/Core/API/CameraEventCollection.swift
@@ -9,7 +9,9 @@ import Foundation
 /// Events that can be used to observe a camera
 public final class CameraEventCollection: EventCollection<Camera> {
     /// Event triggered when the camera was moved
-    public private(set) lazy var moved = Event<Camera, (old: Point, new: Point)>(object: self.object)
+    public private(set) lazy var moved = Event<Camera, (old: Point, new: Point)>(object: object)
     /// Event triggered when the camera was resized
-    public private(set) lazy var resized = Event<Camera, Void>(object: self.object)
+    public private(set) lazy var resized = Event<Camera, Void>(object: object)
+    /// Event triggered when the camera was clicked (on macOS) or tapped (on iOS/tvOS)
+    public private(set) lazy var clicked = Event<Camera, Point>(object: object)
 }

--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -226,6 +226,11 @@ open class Scene: Pluggable, Activatable {
         grid.labelRectDidChange(label)
     }
 
+    internal func handleClick(at point: Point) {
+        events.clicked.trigger(with: point)
+        grid.handleClick(at: point)
+    }
+
     // MARK: - Private
 
     private func pauseStatusDidChange() {

--- a/Sources/Core/Internal/ClickPlugin.swift
+++ b/Sources/Core/Internal/ClickPlugin.swift
@@ -42,23 +42,31 @@ internal final class ClickPlugin: Plugin {
             return
         }
 
-        var point = recognizer.location(in: recognizer.view)
+        let cameraPoint = recognizer.location(in: scene.camera)
+        scene.camera.handleClick(at: cameraPoint)
+
+        let scenePoint = scene.convertCameraPoint(cameraPoint)
+        scene.handleClick(at: scenePoint)
+    }
+}
+
+private extension ClickGestureRecognizer {
+    func location(in camera: Camera) -> Point {
+        var point = location(in: view)
 
         #if os(macOS)
-        point.y = scene.camera.size.height - point.y
+        point.y = camera.size.height - point.y
         #endif
 
-        point.x += scene.camera.rect.minX
-        point.y += scene.camera.rect.minY
+        return point
+    }
+}
 
-        scene.events.clicked.trigger(with: point)
-
-        scene.actors(at: point).forEach { actor in
-            actor.events.clicked.trigger()
-        }
-
-        scene.labels(at: point).forEach { label in
-            label.events.clicked.trigger()
-        }
+private extension Scene {
+    func convertCameraPoint(_ point: Point) -> Point {
+        var point = point
+        point.x += camera.rect.minX
+        point.y += camera.rect.minY
+        return point
     }
 }

--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -144,6 +144,16 @@ internal final class Grid: Activatable {
         updateTiles(for: label, collisionDetector: nil)
     }
 
+    func handleClick(at point: Point) {
+        for actor in actors(at: point) {
+            actor.events.clicked.trigger()
+        }
+
+        for label in labels(at: point) {
+            label.events.clicked.trigger()
+        }
+    }
+
     func removeAllObjects() {
         for actor in actors {
             actor.remove()

--- a/Tests/ImagineEngineTests/CameraTests.swift
+++ b/Tests/ImagineEngineTests/CameraTests.swift
@@ -118,6 +118,20 @@ final class CameraTests: XCTestCase {
         XCTAssertEqual(newPositions, [Point(x: 350, y: 250), Point(x: 350, y: 300)])
     }
 
+    func testObservingClick() {
+        var clickedPoints = [Point]()
+
+        game.scene.camera.events.clicked.observe { _, point in
+            clickedPoints.append(point)
+        }
+
+        game.simulateClick(at: Point(x: 10, y: 20))
+        XCTAssertEqual(clickedPoints, [Point(x: 10, y: 20)])
+
+        game.simulateClick(at: Point(x: 30, y: 40))
+        XCTAssertEqual(clickedPoints, [Point(x: 10, y: 20), Point(x: 30, y: 40)])
+    }
+
     func testAddingAndRemovingPlugin() {
         let plugin = PluginMock<Camera>()
 


### PR DESCRIPTION
With this change `Camera` now has a `clicked` event that can be used to observe clicks within the camera’s coordinate space. This change also includes a refactor to make the click handling handled more by the individual objects and by `Grid`, to make it easier to add more click features in the future.