### PR TITLE
Grid: Handle activation of scene objects when added

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -104,31 +104,21 @@ open class Scene: Pluggable, Activatable {
 
     /// Add an actor to the scene
     public func add(_ actor: Actor) {
-        actor.scene = self
-
         grid.add(actor, in: self)
         actor.addLayer(to: layer)
-        game.map(actor.activate)
-
         events.actorAdded.trigger(with: actor)
     }
 
     /// Add a block to the scene
     public func add(_ block: Block) {
-        block.scene = self
-
-        grid.add(block)
+        grid.add(block, in: self)
         block.addLayer(to: layer)
-        game.map(block.activate)
     }
 
     /// Add a label to the scene
     public func add(_ label: Label) {
-        label.scene = self
-
-        grid.add(label)
+        grid.add(label, in: self)
         label.addLayer(to: layer)
-        game.map(label.activate)
     }
 
     /// Get all actors which rects intersect a given point

--- a/Sources/Core/Internal/Grid.swift
+++ b/Sources/Core/Internal/Grid.swift
@@ -12,6 +12,7 @@ internal final class Grid: Activatable {
     private(set) var labels = Set<Label>()
     private var tiles = [Index : Tile]()
     private var nextZIndex = 0
+    private weak var game: Game?
 
     func add(_ actor: Actor, in scene: Scene) {
         guard actors.insert(actor).inserted else {
@@ -20,6 +21,9 @@ internal final class Grid: Activatable {
 
         actorRectDidChange(actor, in: scene)
         assignZIndexIfNeeded(to: actor)
+
+        actor.scene = scene
+        game.map(actor.activate)
     }
 
     func remove(_ actor: Actor) {
@@ -45,13 +49,16 @@ internal final class Grid: Activatable {
         actor.gridTiles = []
     }
 
-    func add(_ block: Block) {
+    func add(_ block: Block, in scene: Scene) {
         guard blocks.insert(block).inserted else {
             return
         }
 
         blockRectDidChange(block)
         assignZIndexIfNeeded(to: block)
+
+        block.scene = scene
+        game.map(block.activate)
     }
 
     func remove(_ block: Block) {
@@ -72,13 +79,16 @@ internal final class Grid: Activatable {
         block.gridTiles = []
     }
 
-    func add(_ label: Label) {
+    func add(_ label: Label, in scene: Scene) {
         guard labels.insert(label).inserted else {
             return
         }
 
         assignZIndexIfNeeded(to: label)
         labelRectDidChange(label)
+
+        label.scene = scene
+        game.map(label.activate)
     }
 
     func remove(_ label: Label) {
@@ -171,6 +181,8 @@ internal final class Grid: Activatable {
     // MARK: - Activatable
 
     func activate(in game: Game) {
+        self.game = game
+
         for actor in actors {
             actor.activate(in: game)
         }
@@ -185,6 +197,8 @@ internal final class Grid: Activatable {
     }
 
     func deactivate() {
+        game = nil
+
         for actor in actors {
             actor.deactivate()
         }


### PR DESCRIPTION
This change makes `Grid` handle the activation of scene objects when they are added to a scene. This to support the upcoming feature of being able to add scene objects directly to the camera.