### PR TITLE
Scene: Re-activate grid after reset

### DIFF
--- a/Sources/Core/API/Scene.swift
+++ b/Sources/Core/API/Scene.swift
@@ -97,6 +97,7 @@ open class Scene: Pluggable, Activatable {
         game.map(timeline.activate)
         game.map(camera.activate)
         game.map(pluginManager.activate)
+        game.map(grid.activate)
 
         setup()
         activate()

--- a/Tests/ImagineEngineTests/SceneTests.swift
+++ b/Tests/ImagineEngineTests/SceneTests.swift
@@ -234,6 +234,22 @@ final class SceneTests: XCTestCase {
         XCTAssertEqual(game.scene.camera.position, Point(x: 250, y: 250))
     }
 
+    func testActorActivationAfterReset() {
+        game.scene.reset()
+
+        // Adding an actor after reset should immediately activate it
+        let actor = Actor()
+        game.scene.add(actor)
+
+        // Verify activation by adding an action
+        let action = ActionMock<Actor>(duration: 1)
+        actor.perform(action)
+
+        // After one update cycle the action should have been started
+        game.update()
+        XCTAssertTrue(action.isStarted)
+    }
+
     func testPausing() {
         let actor = Actor()
         actor.move(to: Point(x: 100, y: 100), duration: 5)


### PR DESCRIPTION
This patch fixes a recent regression that would prevent a scene’s grid from being reactivated after a reset. This manifested itself by actions not running after a reset, so that’s what I used to reproduce the bug & verify the fix in a test.