### PR TITLE
Multiple lines support for Label

### DIFF
--- a/Sources/Core/API/Label.swift
+++ b/Sources/Core/API/Label.swift
@@ -19,6 +19,8 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, Plugga
     public internal(set) var scene: Scene?
     /// A collection of events that can be used to observe the label.
     public private(set) lazy var events = LabelEventCollection(object: self)
+    /// Multiple lines support. Should fit its size
+    public var shouldWrap = false { didSet { layer.isWrapped = shouldWrap } }
     /// The index of the label on the z axis. Affects rendering. 0 = implicit index.
     public var zIndex = 0 { didSet { layer.zPosition = Metric(zIndex) } }
     /// The position of the label within its scene.

--- a/Sources/Core/API/Label.swift
+++ b/Sources/Core/API/Label.swift
@@ -19,7 +19,7 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, Plugga
     public internal(set) var scene: Scene?
     /// A collection of events that can be used to observe the label.
     public private(set) lazy var events = LabelEventCollection(object: self)
-    /// Multiple lines support. Should fit its size
+    /// Whether the label's text should be wrapped on multiple lines in case it doesn't fit its width.
     public var shouldWrap = false { didSet { layer.isWrapped = shouldWrap } }
     /// The index of the label on the z axis. Affects rendering. 0 = implicit index.
     public var zIndex = 0 { didSet { layer.zPosition = Metric(zIndex) } }

--- a/Tests/ImagineEngineTests/LabelTests.swift
+++ b/Tests/ImagineEngineTests/LabelTests.swift
@@ -25,8 +25,8 @@ final class LabelTests: XCTestCase {
     func testWrapped() {
         // Check its default value (false)
         XCTAssertEqual(label.layer.isWrapped, false)
-        label.shouldWrap = true
         
+        label.shouldWrap = true
         XCTAssertEqual(label.shouldWrap, label.layer.isWrapped)
     }
 

--- a/Tests/ImagineEngineTests/LabelTests.swift
+++ b/Tests/ImagineEngineTests/LabelTests.swift
@@ -25,7 +25,7 @@ final class LabelTests: XCTestCase {
     func testWrapped() {
         // Check its default value (false)
         XCTAssertEqual(label.layer.isWrapped, false)
-        
+
         label.shouldWrap = true
         XCTAssertEqual(label.shouldWrap, label.layer.isWrapped)
     }

--- a/Tests/ImagineEngineTests/LabelTests.swift
+++ b/Tests/ImagineEngineTests/LabelTests.swift
@@ -22,6 +22,13 @@ final class LabelTests: XCTestCase {
     }
 
     // MARK: - Tests
+    func testWrapped() {
+        // Check its default value (false)
+        XCTAssertEqual(label.layer.isWrapped, false)
+        label.shouldWrap = true
+        
+        XCTAssertEqual(label.shouldWrap, label.layer.isWrapped)
+    }
 
     func testAutoResize() {
         // Verify initial size is zero


### PR DESCRIPTION
Created a public property to enable multiple lines using CATextLayer's isWrapped. 