### PR TITLE
SpriteSheet: Add convenience API for initializing with a column/row count

### DIFF
--- a/Sources/Core/API/SpriteSheet.swift
+++ b/Sources/Core/API/SpriteSheet.swift
@@ -66,6 +66,13 @@ public extension SpriteSheet {
         self.init(texture: texture, frameCount: frameCount, rowCount: rowCount)
     }
 
+    /// Initialize an instance with a given column (width) and row (height) count
+    init(textureNamed textureName: String, format: TextureFormat? = nil, columnCount: Int, rowCount: Int) {
+        let texture = Texture(name: textureName, format: format)
+        let frameCount = columnCount * rowCount
+        self.init(texture: texture, frameCount: frameCount, rowCount: rowCount)
+    }
+
     /// Create a slice of this sprite sheet from a range of coordinates
     func slice(from coordinates: ClosedRange<Coordinate>) -> SpriteSheet {
         var sheet = self

--- a/Tests/ImagineEngineTests/SpriteSheetTests.swift
+++ b/Tests/ImagineEngineTests/SpriteSheetTests.swift
@@ -51,4 +51,9 @@ final class SpriteSheetTests: XCTestCase {
         XCTAssertEqual(frame4.contentRect, Rect(x: 0.75, y: 0.5, width: 0.25, height: 0.25))
         #endif
     }
+
+    func testInitializingWithColumnAndRowCount() {
+        let sheet = SpriteSheet(textureNamed: "Sheet", columnCount: 9, rowCount: 7)
+        XCTAssertEqual(sheet.frameCount, 9 * 7)
+    }
 }


### PR DESCRIPTION
This change adds a convenience initializer to `SpriteSheet` that makes it easy to create an instance by just entering the number of rows and columns of a sprite sheet rather than having to calculate the exact frame count (we have computers for that! 😉)