### PR TITLE
Generalize layer transformation code

### DIFF
--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		5204849D1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
 		5204849E1FA353590011D372 /* ClickGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */; };
 		520484A21FA357070011D372 /* ClickGestureRecognizer-macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */; };
+		5209C858208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5209C857208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift */; };
+		5209C859208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5209C857208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift */; };
+		5209C85A208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5209C857208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift */; };
+		5209C85C208BF3510033DB4A /* CALayer+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5209C85B208BF3510033DB4A /* CALayer+Transform.swift */; };
+		5209C85D208BF3510033DB4A /* CALayer+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5209C85B208BF3510033DB4A /* CALayer+Transform.swift */; };
+		5209C85E208BF3510033DB4A /* CALayer+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5209C85B208BF3510033DB4A /* CALayer+Transform.swift */; };
 		521054261FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */; };
 		521054271FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */; };
 		521054281FFD78B1002FCFB6 /* LabelEventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */; };
@@ -349,6 +355,8 @@
 		026CE1C31FC06B7E00A0998B /* CameraEventCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraEventCollection.swift; sourceTree = "<group>"; };
 		5204849C1FA353590011D372 /* ClickGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickGestureRecognizerMock.swift; sourceTree = "<group>"; };
 		5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClickGestureRecognizer-macOS.swift"; sourceTree = "<group>"; };
+		5209C857208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTAssertEqual+CATransform3D.swift"; sourceTree = "<group>"; };
+		5209C85B208BF3510033DB4A /* CALayer+Transform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CALayer+Transform.swift"; sourceTree = "<group>"; };
 		521054251FFD78B1002FCFB6 /* LabelEventCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelEventCollection.swift; sourceTree = "<group>"; };
 		522CD6281F8D4512008DB43D /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		522CD6291F8D4512008DB43D /* ActionPerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionPerformer.swift; sourceTree = "<group>"; };
@@ -586,6 +594,7 @@
 				522CD6511F8D4512008DB43D /* Activatable.swift */,
 				C800CE2C1FA77F74008EE08D /* BundleProtocol.swift */,
 				C8D2FCE41FA493940077B560 /* BundleTextureImageLoader.swift */,
+				5209C85B208BF3510033DB4A /* CALayer+Transform.swift */,
 				5204849F1FA356F80011D372 /* ClickGestureRecognizer-macOS.swift */,
 				522CD6521F8D4512008DB43D /* ClickPlugin.swift */,
 				522CD6531F8D4512008DB43D /* ClosureUpdatable.swift */,
@@ -641,6 +650,7 @@
 				52C860321F8E381600C6C7A7 /* Assert.swift */,
 				52C860331F8E381600C6C7A7 /* TimeTraveler.swift */,
 				52C860341F8E382800C6C7A7 /* ImageMockFactory.swift */,
+				5209C857208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1037,6 +1047,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5209C859208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift in Sources */,
 				525688D01F9CF3E200F87786 /* TextureImageLoaderMock.swift in Sources */,
 				525688C81F9CF3E200F87786 /* EventTests.swift in Sources */,
 				525688CE1F9CF3E200F87786 /* GameMock.swift in Sources */,
@@ -1081,6 +1092,7 @@
 				5253C7B61FA4D57200D304B5 /* Actor.swift in Sources */,
 				52E725941FCF68AB0099FCC7 /* Shadow.swift in Sources */,
 				5253C7A01FA4D56C00D304B5 /* ClickPlugin.swift in Sources */,
+				5209C85E208BF3510033DB4A /* CALayer+Transform.swift in Sources */,
 				5253C7C01FA4D57200D304B5 /* Event.swift in Sources */,
 				5253C7A21FA4D56C00D304B5 /* DisplayLinkProtocol.swift in Sources */,
 				026CE1C61FC06B7E00A0998B /* CameraEventCollection.swift in Sources */,
@@ -1151,6 +1163,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5209C85A208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift in Sources */,
 				5253C7ED1FA4D97D00D304B5 /* TextureImageLoaderMock.swift in Sources */,
 				5253C7EF1FA4D97D00D304B5 /* TimeTraveler.swift in Sources */,
 				5253C7E81FA4D97D00D304B5 /* ActionMock.swift in Sources */,
@@ -1195,6 +1208,7 @@
 				522CD6741F8D451D008DB43D /* ClosureAction.swift in Sources */,
 				52E725921FCF68AB0099FCC7 /* Shadow.swift in Sources */,
 				522CD6841F8D451D008DB43D /* RepeatAction.swift in Sources */,
+				5209C85C208BF3510033DB4A /* CALayer+Transform.swift in Sources */,
 				522CD6931F8D4521008DB43D /* ClosureUpdatable.swift in Sources */,
 				522CD69A1F8D4521008DB43D /* LoadedTexture.swift in Sources */,
 				026CE1C41FC06B7E00A0998B /* CameraEventCollection.swift in Sources */,
@@ -1265,6 +1279,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5209C858208BF3230033DB4A /* XCTAssertEqual+CATransform3D.swift in Sources */,
 				527FC8081F8EB83F006B1295 /* CameraTests.swift in Sources */,
 				52C8603B1F8E535100C6C7A7 /* GameMock.swift in Sources */,
 				52479F861F8E7BFD00D22A87 /* TimeTraveler.swift in Sources */,
@@ -1360,6 +1375,7 @@
 				523E5D111F9FEFBC0084792C /* SpriteSheet.swift in Sources */,
 				DD21B7211F92E75A0034A7CE /* MetricAction.swift in Sources */,
 				DD21B7221F92E75A0034A7CE /* Animation.swift in Sources */,
+				5209C85D208BF3510033DB4A /* CALayer+Transform.swift in Sources */,
 				DD21B7231F92E75A0034A7CE /* Game.swift in Sources */,
 				DD21B7241F92E75A0034A7CE /* Mirroring.swift in Sources */,
 				DD21B7251F92E75A0034A7CE /* Actor.swift in Sources */,

--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -51,7 +51,7 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
     /// The opacity of the actor. Ranges from 0 (transparent) - 1 (opaque).
     public var opacity = Metric(1) { didSet { layer.opacity = Float(opacity) } }
     /// Any mirroring to apply when rendering the actor. See `Mirroring` for options.
-    public var mirroring = Set<Mirroring>() { didSet { layer.mirroring = mirroring } }
+    public var mirroring = Set<Mirroring>() { didSet { applyLayerTransform() } }
     /// The actor's background color. Default is `.clear` (no background).
     public var backgroundColor = Color.clear { didSet { layer.backgroundColor = backgroundColor.cgColor } }
     /// Any shadow that should be rendered beneath the actor. Using shadows may impact performance.
@@ -251,7 +251,7 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
             return
         }
 
-        layer.rotation = rotation
+        applyLayerTransform()
 
         events.rotated.trigger()
     }
@@ -269,7 +269,7 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
             return
         }
 
-        layer.scale = scale
+        applyLayerTransform()
         updateRect()
     }
 
@@ -349,6 +349,10 @@ public final class Actor: SceneObject, InstanceHashable, ActionPerformer,
                scale: animation.textureScale,
                resize: animation.autoResize,
                ignoreNamePrefix: animation.ignoreTextureNamePrefix)
+    }
+
+    private func applyLayerTransform() {
+        layer.applyTransform(withRotation: rotation, scale: scale, mirroring: mirroring)
     }
 }
 

--- a/Sources/Core/API/Label.swift
+++ b/Sources/Core/API/Label.swift
@@ -167,7 +167,7 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, Plugga
             return
         }
 
-        layer.rotation = rotation
+        applyLayerTransform()
 
         events.rotated.trigger()
     }
@@ -177,7 +177,7 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, Plugga
             return
         }
 
-        layer.scale = scale
+        applyLayerTransform()
     }
 
     private func autoResize() {
@@ -196,6 +196,10 @@ public final class Label: SceneObject, InstanceHashable, ActionPerformer, Plugga
 
     private func horizontalAlignmentDidChange() {
         layer.alignmentMode = horizontalAlignment.mode
+    }
+
+    private func applyLayerTransform() {
+        layer.applyTransform(withRotation: rotation, scale: scale, mirroring: [])
     }
 }
 

--- a/Sources/Core/Internal/CALayer+Transform.swift
+++ b/Sources/Core/Internal/CALayer+Transform.swift
@@ -1,0 +1,22 @@
+import Foundation
+import QuartzCore
+
+internal extension CALayer {
+    func applyTransform(withRotation rotation: Metric,
+                        scale: Metric,
+                        mirroring: Set<Mirroring>) {
+        var newTransform = CATransform3DIdentity
+        newTransform = CATransform3DRotate(newTransform, rotation, 0, 0, 1)
+        newTransform = CATransform3DScale(newTransform, scale, scale, 1)
+
+        if mirroring.contains(.horizontal) {
+            newTransform = CATransform3DScale(newTransform, -1, 1, 1)
+        }
+
+        if mirroring.contains(.vertical) {
+            newTransform = CATransform3DScale(newTransform, 1, -1, 1)
+        }
+
+        transform = newTransform
+    }
+}

--- a/Sources/Core/Internal/Layer.swift
+++ b/Sources/Core/Internal/Layer.swift
@@ -8,10 +8,6 @@ import Foundation
 import QuartzCore
 
 internal final class Layer: CALayer {
-    var rotation: Metric = 0 { didSet { updateTransform() } }
-    var scale: Metric = 1 { didSet { updateTransform() } }
-    var mirroring = Set<Mirroring>() { didSet { updateTransform() } }
-
     // MARK: - Initializers
 
     override init() {
@@ -30,23 +26,5 @@ internal final class Layer: CALayer {
 
     override func action(forKey event: String) -> CAAction? {
         return NSNull()
-    }
-
-    // MARK: - Private
-
-    private func updateTransform() {
-        var newTransform = CATransform3DIdentity
-        newTransform = CATransform3DRotate(newTransform, rotation, 0, 0, 1)
-        newTransform = CATransform3DScale(newTransform, scale, scale, 1)
-
-        if mirroring.contains(.horizontal) {
-            newTransform = CATransform3DScale(newTransform, -1, 1, 1)
-        }
-
-        if mirroring.contains(.vertical) {
-            newTransform = CATransform3DScale(newTransform, 1, -1, 1)
-        }
-
-        transform = newTransform
     }
 }

--- a/Sources/Core/Internal/TextLayer.swift
+++ b/Sources/Core/Internal/TextLayer.swift
@@ -8,20 +8,7 @@ import Foundation
 import QuartzCore
 
 internal final class TextLayer: CATextLayer {
-
-    var rotation: Metric = 0 { didSet { updateTransform() } }
-    var scale: Metric = 1 { didSet { updateTransform() } }
-
     override func action(forKey event: String) -> CAAction? {
         return NSNull()
-    }
-
-    // MARK: - Private
-
-    private func updateTransform() {
-        var newTransform = CATransform3DIdentity
-        newTransform = CATransform3DScale(newTransform, scale, scale, 1)
-        newTransform = CATransform3DRotate(newTransform, rotation, 0, 0, 1)
-        transform = newTransform
     }
 }

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -371,7 +371,7 @@ final class ActorTests: XCTestCase {
         actor.rotation = 2
 
         XCTAssertEqual(triggerCount, 2)
-        XCTAssertEqual(actor.layer.rotation, 2, accuracy: 0.001)
+        XCTAssertEqual(CATransform3DMakeRotation(2, 0, 0, 1), actor.layer.transform)
     }
 
     func testObservingCollisionsWithOtherActor() {

--- a/Tests/ImagineEngineTests/LabelTests.swift
+++ b/Tests/ImagineEngineTests/LabelTests.swift
@@ -144,14 +144,16 @@ final class LabelTests: XCTestCase {
 
         // Upscale the label
         label.scale = upscaleFactor
-        XCTAssertEqual(label.layer.scale, upscaleFactor)
+        XCTAssertEqual(CATransform3DMakeScale(upscaleFactor, upscaleFactor, 1),
+                       label.layer.transform)
 
         // Downscale the label
         label.scale = downscaleFactor
-        XCTAssertEqual(label.layer.scale, downscaleFactor)
+        XCTAssertEqual(CATransform3DMakeScale(downscaleFactor, downscaleFactor, 1),
+                       label.layer.transform)
 
         // Back to original size
         label.scale = 1
-        XCTAssertEqual(label.layer.scale, 1)
+        XCTAssertEqual(CATransform3DIdentity, label.layer.transform)
     }
 }

--- a/Tests/ImagineEngineTests/Utilities/XCTAssertEqual+CATransform3D.swift
+++ b/Tests/ImagineEngineTests/Utilities/XCTAssertEqual+CATransform3D.swift
@@ -1,0 +1,12 @@
+import Foundation
+import XCTest
+import QuartzCore
+
+func XCTAssertEqual(_ transformA: CATransform3D,
+                    _ transformB: CATransform3D,
+                    file: StaticString = #file,
+                    line: UInt = #line) {
+    let valueA = NSValue(caTransform3D: transformA)
+    let valueB = NSValue(caTransform3D: transformB)
+    XCTAssertEqual(valueA, valueB, file: file, line: line)
+}


### PR DESCRIPTION
This change refactors the layer transformation code from being concrete implementations on `Layer` and `TextLayer` to be a more generalized extension on any `CALayer`. This to enable more `CALayer` subclasses to easily be introduced, and to be able to reduce code duplication.