### PR TITLE
Actor: Rework contact management to support edge-to-edge contacts

### DIFF
--- a/Sources/Core/API/Actor.swift
+++ b/Sources/Core/API/Actor.swift
@@ -155,27 +155,6 @@ public final class Actor: Node<CALayer>, InstanceHashable, ActionPerformer,
     internal func remove(from gridTile: Grid.Tile) {
         gridTile.actors.remove(self)
         gridTiles.remove(gridTile)
-
-        for otherActor in gridTile.actors {
-            guard otherActor.actorsInContact.contains(self) else {
-                continue
-            }
-
-            guard !otherActor.rectForCollisionDetection.intersects(rectForCollisionDetection) else {
-                continue
-            }
-
-            otherActor.actorsInContact.remove(self)
-            actorsInContact.remove(otherActor)
-        }
-
-        for block in gridTile.blocks {
-            guard block.actorsInContact.remove(self) != nil else {
-                continue
-            }
-
-            blocksInContact.remove(block)
-        }
     }
 
     // MARK: - Internal

--- a/Sources/Core/API/Block.swift
+++ b/Sources/Core/API/Block.swift
@@ -85,14 +85,6 @@ public final class Block: Node<CALayer>, InstanceHashable, ActionPerformer, ZInd
     internal func remove(from gridTile: Grid.Tile) {
         gridTile.blocks.remove(self)
         gridTiles.remove(gridTile)
-
-        for actor in gridTile.actors {
-            guard actor.blocksInContact.remove(self) != nil else {
-                continue
-            }
-
-            actorsInContact.remove(actor)
-        }
     }
 
     // MARK: - Private

--- a/Tests/ImagineEngineTests/ActorTests.swift
+++ b/Tests/ImagineEngineTests/ActorTests.swift
@@ -696,6 +696,28 @@ final class ActorTests: XCTestCase {
         XCTAssertTrue(actor.isInContact(with: block))
     }
 
+    func testIsInContactWithBlockWithNoOverlappingConstraint() {
+        let blockSize = Size(width: 100, height: 100)
+        let blockGroup = Group.name("BlockInContact")
+        let block = Block(size: blockSize, textureCollectionName: "BlockInContact")
+        block.group = blockGroup
+        game.scene.add(block)
+
+        actor.size = Size(width: 50, height: 50)
+        actor.position = Point(x: 300, y: 0)
+
+        actor.constraints.insert(.neverOverlapBlockInGroup(blockGroup))
+        actor.position = Point(x: 50, y: 0)
+
+        // Since actor can't overlap the block, it should be right outside of it,
+        // but still be in contact
+        XCTAssertEqual(actor.position, Point(x: 75, y: 0))
+        XCTAssertTrue(actor.isInContact(with: block))
+
+        // Moving the actor away should break the contact
+        actor.position.x += 1
+        XCTAssertFalse(actor.isInContact(with: block))
+    }
 }
 
 private extension Size {


### PR DESCRIPTION
This changes the way contacts are managed between actors and blocks, and pushes the responsibility of managing object contacts back to `Grid`, instead of being handled in each separate object.

The new implementation is more robust, since it invalidates contacts on each rect change, rather than just when an object moves between different grid tiles. It also now treats edge-to-edge contacts (that is, no overlap but a distance of 1 pixel or less between two objects) as a contact. This is really useful in platform games, when you want to check if the player is currently standing on the ground, for example.