### PR TITLE
Animation: Support specifying a texture scale

### DIFF
--- a/Sources/Core/API/Animation.swift
+++ b/Sources/Core/API/Animation.swift
@@ -49,7 +49,8 @@ public extension Animation {
          repeatMode: RepeatMode = .forever,
          autoResize: Bool = true,
          ignoreTextureNamePrefix: Bool = false,
-         textureFormat: TextureFormat = .png) {
+         textureFormat: TextureFormat = .png,
+         textureScale: Int? = nil) {
         self.content = .frames(withBaseName: name,
                                indexSeparator: frameIndexSeparator,
                                format: textureFormat,
@@ -58,6 +59,7 @@ public extension Animation {
         self.repeatMode = repeatMode
         self.autoResize = autoResize
         self.ignoreTextureNamePrefix = ignoreTextureNamePrefix
+        self.textureScale = textureScale
         updateIdentifier()
     }
 


### PR DESCRIPTION
When creating an animation, a specific texture scale can now be used when automatically creating an animation from a series of textures.