### PR TITLE
Updating Hashable support to Swift 5 format on InstanceHashable.swift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-osx_image: xcode10.1
+osx_image: xcode10.2
 script:
     - bundle exec fastlane tests

--- a/ImagineEngine.xcodeproj/project.pbxproj
+++ b/ImagineEngine.xcodeproj/project.pbxproj
@@ -907,7 +907,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = ImagineEngine;
 				TargetAttributes = {
 					525688B91F9CF33100F87786 = {
@@ -930,16 +930,17 @@
 					};
 					52D6D9851BEFF229002C0205 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 52D6D9761BEFF229002C0205 /* Build configuration list for PBXProject "ImagineEngine" */;
 			compatibilityVersion = "Xcode 6.3";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 52D6D9721BEFF229002C0205;
 			productRefGroup = 52D6D97D1BEFF229002C0205 /* Products */;
@@ -1591,6 +1592,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1650,6 +1652,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1718,7 +1721,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1740,7 +1743,7 @@
 				PRODUCT_NAME = ImagineEngine;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1755,7 +1758,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1769,7 +1772,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ImagineEngine.ImagineEngine-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/ImagineEngine.xcodeproj/xcshareddata/xcschemes/ImagineEngine-iOS.xcscheme
+++ b/ImagineEngine.xcodeproj/xcshareddata/xcschemes/ImagineEngine-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ImagineEngine.xcodeproj/xcshareddata/xcschemes/ImagineEngine-macOS.xcscheme
+++ b/ImagineEngine.xcodeproj/xcshareddata/xcschemes/ImagineEngine-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ImagineEngine.xcodeproj/xcshareddata/xcschemes/ImagineEngine-tvOS.xcscheme
+++ b/ImagineEngine.xcodeproj/xcshareddata/xcschemes/ImagineEngine-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Core/API/InstanceHashable.swift
+++ b/Sources/Core/API/InstanceHashable.swift
@@ -14,8 +14,9 @@ extension InstanceHashable {
     public static func ==(lhs: Self, rhs: Self) -> Bool {
         return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
-
-    public var hashValue: Int {
-        return ObjectIdentifier(self).hashValue
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
+    
 }

--- a/Sources/Core/API/InstanceHashable.swift
+++ b/Sources/Core/API/InstanceHashable.swift
@@ -14,9 +14,7 @@ extension InstanceHashable {
     public static func ==(lhs: Self, rhs: Self) -> Bool {
         return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
-    
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(self))
     }
-    
 }

--- a/Sources/Core/API/Pluggable.swift
+++ b/Sources/Core/API/Pluggable.swift
@@ -37,6 +37,6 @@ public extension Pluggable {
     /// Add a plugin to this object, reusing an existing instance of the same type if possible
     /// - Returns: The plugin that was either added or reused
     @discardableResult func add<P: Plugin>(_ plugin: @autoclosure () -> P) -> P where P.Object == PluginTarget {
-        return add(plugin, reuseExistingOfSameType: true)
+        return add(plugin(), reuseExistingOfSameType: true)
     }
 }

--- a/Tests/ImagineEngineTests/Utilities/Assert.swift
+++ b/Tests/ImagineEngineTests/Utilities/Assert.swift
@@ -50,7 +50,7 @@ public func assertErrorThrown<T, E: Error>(at file: StaticString = #file,
                                            line: UInt = #line,
                                            _ errorExpression: @autoclosure () -> E,
                                            by closure: () throws -> T) where E: Equatable {
-    assert(at: file, line: line, try closure(), throwsError: errorExpression)
+    assert(at: file, line: line, try closure(), throwsError: errorExpression())
 }
 
 /**


### PR DESCRIPTION
This update enables the source to compile as Swift 5. The test suites all still pass, and no changes to the user-visible API have been made. 